### PR TITLE
Add tests for the example KDL files

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,13 @@ pub enum KdlErrorKind {
     Other,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Error)]
+#[error("Failed to convert from KdlNodeValue::{variant} to {expected}.")]
+pub struct TryFromKdlNodeValueError {
+    pub(crate) expected: &'static str,
+    pub(crate) variant: &'static str,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct KdlParseError<I> {
     pub(crate) input: I,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use nom::combinator::all_consuming;
 use nom::Finish;
 
-pub use crate::error::{KdlError, KdlErrorKind};
+pub use crate::error::{KdlError, KdlErrorKind, TryFromKdlNodeValueError};
 pub use crate::node::{KdlNode, KdlNodeValue};
 
 mod error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,3 +16,67 @@ pub enum KdlNodeValue {
     Boolean(bool),
     Null,
 }
+
+// Support conversions from base types into KdlNodeValue
+
+impl From<i64> for KdlNodeValue {
+    fn from(v: i64) -> Self {
+        Self::Int(v)
+    }
+}
+
+impl From<f64> for KdlNodeValue {
+    fn from(v: f64) -> Self {
+        Self::Float(v)
+    }
+}
+
+impl From<String> for KdlNodeValue {
+    fn from(v: String) -> Self {
+        Self::String(v)
+    }
+}
+
+impl From<&str> for KdlNodeValue {
+    fn from(v: &str) -> Self {
+        Self::String(v.to_owned())
+    }
+}
+
+impl From<bool> for KdlNodeValue {
+    fn from(v: bool) -> Self {
+        Self::Boolean(v)
+    }
+}
+
+impl<T> From<Option<T>> for KdlNodeValue
+where
+    T: Into<KdlNodeValue>,
+{
+    fn from(v: Option<T>) -> Self {
+        v.map_or(KdlNodeValue::Null, |v| v.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from() {
+        assert_eq!(KdlNodeValue::from(1), KdlNodeValue::Int(1));
+        assert_eq!(KdlNodeValue::from(1.5), KdlNodeValue::Float(1.5));
+        assert_eq!(
+            KdlNodeValue::from("foo".to_owned()),
+            KdlNodeValue::String("foo".to_owned())
+        );
+        assert_eq!(
+            KdlNodeValue::from("bar"),
+            KdlNodeValue::String("bar".to_owned())
+        );
+        assert_eq!(KdlNodeValue::from(true), KdlNodeValue::Boolean(true));
+
+        assert_eq!(KdlNodeValue::from(None::<i64>), KdlNodeValue::Null);
+        assert_eq!(KdlNodeValue::from(Some(1)), KdlNodeValue::Int(1));
+    }
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryFrom};
+
+use crate::TryFromKdlNodeValueError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct KdlNode {
@@ -58,6 +60,62 @@ where
     }
 }
 
+// Support reverse conversions using TryFrom
+
+// Synthesizes a TryFrom impl for both the base type and an Option variant.
+//
+// We need the Option variant because we can't write a blanket impl due to the existing
+//   impl<T, U> TryFrom<U> for T where U: Into<T>
+// even though KdlNodeValue does not implement Into<Option<_>>.
+macro_rules! impl_try_from {
+    (<$($lt:lifetime)?> $source:ty => $typ:ty, $($good:pat => $value:expr),+; $($bad:ident),+) => {
+        impl<$($lt)?> TryFrom<$source> for $typ {
+            type Error = TryFromKdlNodeValueError;
+            fn try_from(value: $source) -> Result<Self, Self::Error> {
+                match value {
+                    $( $good => Ok($value), )+
+                    $( KdlNodeValue::$bad(_) => Err(TryFromKdlNodeValueError {
+                        expected: stringify!($typ),
+                        variant: stringify!($bad)
+                    }), )+
+                    KdlNodeValue::Null => Err(TryFromKdlNodeValueError {
+                        expected: stringify!($typ),
+                        variant: "Null"
+                    }),
+                }
+            }
+        }
+        impl<$($lt)?> TryFrom<$source> for Option<$typ> {
+            type Error = TryFromKdlNodeValueError;
+            fn try_from(value: $source) -> Result<Self, Self::Error> {
+                match value {
+                    $( $good => Ok(Some($value)), )+
+                    $( KdlNodeValue::$bad(_) => Err(TryFromKdlNodeValueError {
+                        expected: concat!("Option::<", stringify!($typ), ">"),
+                        variant: stringify!($bad)
+                    }), )+
+                    KdlNodeValue::Null => Ok(None),
+                }
+            }
+        }
+    };
+    (& $($lt:lifetime)?, $typ:ty, $($tt:tt)*) => {
+        impl_try_from!(<$($lt)?> & $($lt)? KdlNodeValue => $typ, $($tt)*);
+    };
+    ($typ:ty, $($tt:tt)*) => {
+        impl_try_from!(<> KdlNodeValue => $typ, $($tt)*);
+    };
+}
+
+impl_try_from!(i64, KdlNodeValue::Int(v) => v; Float, String, Boolean);
+impl_try_from!(&, i64, KdlNodeValue::Int(v) => *v; Float, String, Boolean);
+impl_try_from!(f64, KdlNodeValue::Float(v) => v; Int, String, Boolean);
+impl_try_from!(&, f64, KdlNodeValue::Float(v) => *v; Int, String, Boolean);
+impl_try_from!(String, KdlNodeValue::String(v) => v; Int, Float, Boolean);
+impl_try_from!(&'a, &'a str, KdlNodeValue::String(v) => &v[..]; Int, Float, Boolean);
+impl_try_from!(bool, KdlNodeValue::Boolean(v) => v; Int, Float, String);
+impl_try_from!(&, bool, KdlNodeValue::Boolean(v) => *v; Int, Float, String);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +136,43 @@ mod tests {
 
         assert_eq!(KdlNodeValue::from(None::<i64>), KdlNodeValue::Null);
         assert_eq!(KdlNodeValue::from(Some(1)), KdlNodeValue::Int(1));
+    }
+
+    #[test]
+    fn try_from_success() {
+        assert_eq!(i64::try_from(KdlNodeValue::Int(1)), Ok(1));
+        assert_eq!(i64::try_from(&KdlNodeValue::Int(1)), Ok(1));
+        assert_eq!(f64::try_from(KdlNodeValue::Float(1.5)), Ok(1.5));
+        assert_eq!(f64::try_from(&KdlNodeValue::Float(1.5)), Ok(1.5));
+        assert_eq!(
+            String::try_from(KdlNodeValue::String("foo".to_owned())),
+            Ok("foo".to_owned())
+        );
+        assert_eq!(
+            <&str as TryFrom<_>>::try_from(&KdlNodeValue::String("foo".to_owned())),
+            Ok("foo")
+        );
+        assert_eq!(bool::try_from(KdlNodeValue::Boolean(true)), Ok(true));
+        assert_eq!(bool::try_from(&KdlNodeValue::Boolean(true)), Ok(true));
+
+        assert_eq!(Option::<i64>::try_from(KdlNodeValue::Int(1)), Ok(Some(1)));
+        assert_eq!(Option::<i64>::try_from(KdlNodeValue::Null), Ok(None));
+    }
+
+    #[test]
+    fn try_from_failure() {
+        // We don't expose the internal format of the error type, so let's just test the message
+        // for a couple of cases.
+        assert_eq!(
+            format!("{}", i64::try_from(KdlNodeValue::Float(1.5)).unwrap_err()),
+            "Failed to convert from KdlNodeValue::Float to i64."
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Option::<i64>::try_from(KdlNodeValue::Float(1.5)).unwrap_err()
+            ),
+            "Failed to convert from KdlNodeValue::Float to Option::<i64>."
+        );
     }
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,0 +1,108 @@
+//! Tests the kdl files in the examples directory.
+
+use kdl::*;
+use std::collections::HashMap;
+
+/// Helper for constructing nodes.
+///
+/// This takes input that's similar to KDL itself, but each node must be terminated with either
+/// a semicolon or a braced block. Nodes whose name contains characters not valid in Rust
+/// identifiers must be written as a string literal instead.
+macro_rules! nodes {
+    ([$v:ident]:name) => {};
+    ([$v:ident]:name $name:ident $($tt:tt)*) => {
+        nodes!([$v]:values stringify!($name); {} {} $($tt)*)
+    };
+    ([$v:ident]:name $name:literal $($tt:tt)*) => {
+        nodes!([$v]:values $name; {} {} $($tt)*)
+    };
+    ([$v:ident]:values $name:expr; {$($value:literal,)*} $props:tt $new_value:literal $($tt:tt)*) => {
+        nodes!([$v]:values $name; {$($value,)* $new_value,} $props $($tt)*)
+    };
+    ([$v:ident]:values $name:expr; $values:tt {$($key:ident=$prop:literal,)*} $new_key:ident=$new_prop:literal $($tt:tt)*) => {
+        nodes!([$v]:values $name; $values {$($key=$prop,)* $new_key=$new_prop,} $($tt)*)
+    };
+    ([$v:ident]:values $name:expr; $values:tt $props:tt $(; $($tt:tt)*)?) => {
+        nodes!([$v]:values $name; $values $props {} $($($tt)*)?)
+    };
+    ([$v:ident]:values $name:expr; {$($value:literal,)*} {$($key:ident=$prop:literal,)*} {$($child:tt)*} $($tail:tt)*) => {
+        $v.push(KdlNode {
+            name: $name.to_owned(),
+            values: vec![$( $value.to_owned().into() ),*],
+            properties: {
+                #[allow(unused_mut)]
+                let mut map = HashMap::new();
+                $(
+                    map.insert(stringify!($key).to_owned(), $prop.to_owned().into());
+                )*
+                map
+            },
+            children: nodes!($($child)*),
+        });
+        nodes!([$v]:name $($tail)*);
+    };
+    // Explicitly match literal and ident at the start instead of $($tt:tt)*
+    // so we get better errors than "recursion limit exceeded" if we fail to match.
+    (:start $($tt:tt)+) => {{
+        let mut v = Vec::new();
+        nodes!([v]:name $($tt)+);
+        v
+    }};
+    ($name:literal $($tt:tt)*) => {
+        nodes!(:start $name $($tt)*)
+    };
+    ($name:ident $($tt:tt)*) => {
+        nodes!(:start $name $($tt)*)
+    };
+    () => { vec![] }
+}
+
+#[test]
+fn test_ci() {
+    let doc = parse_document(include_str!("../examples/ci.kdl"));
+    let nodes = nodes! {
+        name "CI";
+        on "push" "pull_request";
+        env {
+            RUSTFLAGS "-Dwarnings"
+        }
+        jobs {
+            fmt_and_docs "Check fmt & build docs" {
+                "runs-on" "ubuntu-latest";
+                steps {
+                    step uses="actions/checkout@v1";
+                    step "Install Rust" uses="actions-rs/toolchain@v1" {
+                        profile "minimal";
+                        toolchain "stable";
+                        components "rustfmt";
+                        override true;
+                    }
+                    step "rustfmt" run="cargo fmt --all -- --check";
+                    step "docs" run="cargo doc --no-deps";
+                }
+            }
+            build_and_test "Build & Test" {
+                "runs-on" "${{ matrix.os }}";
+                strategy {
+                    matrix {
+                        rust "1.46.0" "stable";
+                        os "ubuntu-latest" "macOS-latest" "windows-latest";
+                    }
+                }
+
+                steps {
+                    step uses="actions/checkout@v1";
+                    step "Install Rust" uses="actions-rs/toolchain@v1" {
+                        profile "minimal";
+                        toolchain "${{ matrix.rust }}";
+                        components "clippy";
+                        override true;
+                    }
+                    step "Clippy" run="cargo clippy --all -- -D warnings";
+                    step "Run tests" run="cargo test --all --verbose";
+                }
+            }
+        }
+    };
+    assert_eq!(doc, Ok(nodes));
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -106,3 +106,23 @@ fn test_ci() {
     };
     assert_eq!(doc, Ok(nodes));
 }
+
+#[test]
+fn test_cargo() {
+    let doc = parse_document(include_str!("../examples/cargo.kdl"));
+    let nodes = nodes! {
+        package {
+            name "kdl";
+            version "0.0.0";
+            description "kat's document language";
+            authors "Kat Marchán <kzm@zkat.tech>";
+            "license-file" "LICENSE.md";
+            edition "2018";
+        }
+        dependencies {
+            nom "6.0.1";
+            thiserror "1.0.22";
+        }
+    };
+    assert_eq!(doc, Ok(nodes));
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -126,3 +126,11 @@ fn test_cargo() {
     };
     assert_eq!(doc, Ok(nodes));
 }
+
+#[test]
+fn test_nuget() {
+    let doc = parse_document(include_str!("../examples/nuget.kdl"));
+    // This file is particularly large. It would be nice to validate it, but for now
+    // I'm just going to settle for making sure it parses.
+    doc.expect("Parsing failed");
+}


### PR DESCRIPTION
This PR adds tests for the `examples/*.kdl` files, to ensure they parse and match the expected contents.

I may have gone a little overboard with the tests. I went down a rabbit hole and wrote a Rust macro that parses very-nearly-KDL (main differences for the test files being nodes need to be semicolon-terminated if they don't have children, and a node whose title contains non-identifier characters needs to be quoted). This was because I wanted to compare the parsed contents of the files, not just whether or not they parse at all. Though for `examples/nuget.kdl` I only tested whether or not it parses, since it's large enough that I didn't want to embed a copy of it into the test.

The ci.kdl and nuget.kdl tests currently fail to parse, but the Cargo.kdl test passes.

This PR is based on #4 and #5.