### PR TITLE
Add line, column to KdlError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use nom::error::{ContextError, ErrorKind, FromExternalError, ParseError};
 
 use thiserror::Error;
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
-#[error("Error parsing document. {kind}")]
+#[error("Error parsing document at line {line} column {column}. {kind}")]
 pub struct KdlError {
     pub input: String,
     /// Offset in chars of the error.
@@ -24,8 +24,6 @@ pub enum KdlErrorKind {
     ParseFloatError(ParseFloatError),
     #[error("Failed to parse {0} component of semver string.")]
     Context(&'static str),
-    #[error("Incomplete input to semver parser.")]
-    IncompleteInput,
     #[error("An unspecified error occurred.")]
     Other,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,12 @@ use thiserror::Error;
 #[error("Error parsing document. {kind}")]
 pub struct KdlError {
     pub input: String,
+    /// Offset in chars of the error.
     pub offset: usize,
+    /// 1-based line number of the error.
+    pub line: usize,
+    /// 1-based column number (in chars) of the error.
+    pub column: usize,
     pub kind: KdlErrorKind,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,22 +16,42 @@ where
     match all_consuming(parser::nodes)(input) {
         Ok((_, arg)) => Ok(arg),
         Err(err) => Err(match err {
-            Err::Error(e) | Err::Failure(e) => KdlError {
-                input: input.into(),
-                offset: e.input.as_ptr() as usize - input.as_ptr() as usize,
-                kind: if let Some(kind) = e.kind {
-                    kind
-                } else if let Some(ctx) = e.context {
-                    KdlErrorKind::Context(ctx)
-                } else {
-                    KdlErrorKind::Other
-                },
-            },
-            Err::Incomplete(_) => KdlError {
-                input: input.into(),
-                offset: input.len() - 1,
-                kind: KdlErrorKind::IncompleteInput,
-            },
+            Err::Error(e) | Err::Failure(e) => {
+                let prefix = &input[..(input.len() - e.input.len())];
+                let (line, column) = calculate_line_column(prefix);
+                KdlError {
+                    input: input.into(),
+                    offset: prefix.chars().count(),
+                    line,
+                    column,
+                    kind: if let Some(kind) = e.kind {
+                        kind
+                    } else if let Some(ctx) = e.context {
+                        KdlErrorKind::Context(ctx)
+                    } else {
+                        KdlErrorKind::Other
+                    },
+                }
+            }
+            Err::Incomplete(_) => {
+                let (line, column) = calculate_line_column(input);
+                KdlError {
+                    input: input.into(),
+                    offset: input.chars().count(),
+                    line,
+                    column,
+                    kind: KdlErrorKind::IncompleteInput,
+                }
+            }
         }),
     }
+}
+
+/// Calculates the line and column of the end of a `&str`.
+///
+/// If the line ends on a newline, the (line, column) pair is placed on the previous line instead.
+fn calculate_line_column(input: &str) -> (usize, usize) {
+    let (input, skipped_lines) = parser::count_leading_lines(input);
+    let input = parser::strip_trailing_newline(input);
+    (skipped_lines + 1, input.len() + 1) // +1 as we're 1-based
 }


### PR DESCRIPTION
This calculates a line and column number for `KdlError`. We could plausibly defer this calculation until someone asks for it, but by doing it upfront it means they show up in the error's debug and display output. It also changes the `offset` field to be char-based instead of byte-based.

This also cleans up `parse_document()` a little. We don't need to worry about `Err::Incomplete`, those errors aren't generated by the `complete` family of parsers (which we're using), so we can just use the `.finish()` method to unwrap the `Err` for us.