### PR TITLE
Export KdlNodeValue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use nom::combinator::all_consuming;
 use nom::Err;
 
 pub use crate::error::{KdlError, KdlErrorKind};
-pub use crate::node::KdlNode;
+pub use crate::node::{KdlNode, KdlNodeValue};
 
 mod error;
 mod node;


### PR DESCRIPTION
This needs to be exported or clients can't construct their own, or even pattern-match against the values.