### PR TITLE
implemented Display for KdlNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ edition = "2018"
 
 [dependencies]
 nom = "6.0.1"
+phf = { version = "0.8.0", features = ["macros"] }
 thiserror = "1.0.22"

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use std::{fmt, collections::HashMap, convert::TryFrom};
+use std::{collections::HashMap, convert::TryFrom, fmt};
 
 use crate::TryFromKdlNodeValueError;
 
@@ -27,29 +27,28 @@ impl fmt::Display for KdlNode {
 
 impl KdlNode {
     fn write(&self, f: &mut fmt::Formatter<'_>, indent: usize) -> fmt::Result {
-
-        write!(f, "{:indent$}", "", indent=indent)?;
+        write!(f, "{:indent$}", "", indent = indent)?;
 
         display_identifier(f, &self.name)?;
         for arg in &self.values {
             write!(f, " {}", arg)?;
         }
-        for (prop,value) in &self.properties {
+        for (prop, value) in &self.properties {
             write!(f, " ")?;
             display_identifier(f, prop)?;
             write!(f, "={}", value)?;
         }
 
-        if self.children.len() == 0 {
-            return Ok(())
+        if self.children.is_empty() {
+            return Ok(());
         }
 
         writeln!(f, " {{")?;
         for child in &self.children {
-            child.write(f, indent+2)?;
-            writeln!(f,"")?;
+            child.write(f, indent + 2)?;
+            writeln!(f)?;
         }
-        write!(f,"}}")?;
+        write!(f, "}}")?;
 
         Ok(())
     }
@@ -70,8 +69,7 @@ impl fmt::Display for KdlValue {
 fn display_identifier(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
     if let Ok(("", identifier)) = crate::parser::bare_identifier(s) {
         write!(f, "{}", identifier)
-    }
-    else {
+    } else {
         display_string(f, s)
     }
 }
@@ -95,7 +93,7 @@ fn display_string(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
     if current > longest {
         longest = current;
     }
-    
+
     write!(f, "r")?;
 
     for _ in 0..longest {
@@ -107,7 +105,7 @@ fn display_string(f: &mut fmt::Formatter<'_>, s: &str) -> fmt::Result {
     for _ in 0..longest {
         write!(f, "#")?;
     }
-    
+
     Ok(())
 }
 
@@ -219,8 +217,14 @@ mod tests {
         assert_eq!("true", format!("{}", KdlValue::Boolean(true)));
         assert_eq!("false", format!("{}", KdlValue::Boolean(false)));
         assert_eq!("null", format!("{}", KdlValue::Null));
-        assert_eq!(r#"r"foo""#, format!("{}", KdlValue::String("foo".to_owned())));
-        assert_eq!(r##"r#"foo "bar" baz"#"##, format!("{}", KdlValue::String(r#"foo "bar" baz"#.to_owned())));
+        assert_eq!(
+            r#"r"foo""#,
+            format!("{}", KdlValue::String("foo".to_owned()))
+        );
+        assert_eq!(
+            r##"r#"foo "bar" baz"#"##,
+            format!("{}", KdlValue::String(r#"foo "bar" baz"#.to_owned()))
+        );
     }
 
     #[test]
@@ -241,25 +245,28 @@ mod tests {
     fn display_nested_node() {
         let value = KdlNode {
             name: "foo".into(),
-            values: vec![ 1.into(), "two".into() ],
+            values: vec![1.into(), "two".into()],
             properties: HashMap::new(),
             children: vec![
                 KdlNode {
                     name: "bar".into(),
-                    values: vec![ 1.into() ],
+                    values: vec![1.into()],
                     properties: HashMap::new(),
                     children: vec![],
                 },
                 KdlNode {
                     name: "baz".into(),
-                    values: vec![ 2.into() ],
+                    values: vec![2.into()],
                     properties: HashMap::new(),
                     children: vec![],
                 },
             ],
         };
 
-        assert_eq!("foo 1 r\"two\" {\n  bar 1\n  baz 2\n}", format!("{}", value));
+        assert_eq!(
+            "foo 1 r\"two\" {\n  bar 1\n  baz 2\n}",
+            format!("{}", value)
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,7 +113,7 @@ pub(crate) fn node(input: &str) -> IResult<&str, Option<KdlNode>, KdlParseError<
 }
 
 /// `bare_identifier := [a-zA-Z_] [a-zA-Z0-9!$%&'*+\-./:<>?@\^_|~]*`
-pub (crate) fn bare_identifier(input: &str) -> IResult<&str, &str, KdlParseError<&str>> {
+pub(crate) fn bare_identifier(input: &str) -> IResult<&str, &str, KdlParseError<&str>> {
     recognize(pair(
         alt((alpha1, tag("_"))),
         many0(alt((alphanumeric1, recognize(one_of("~!@$%^&*-_+./:<>?"))))),
@@ -122,10 +122,7 @@ pub (crate) fn bare_identifier(input: &str) -> IResult<&str, &str, KdlParseError
 
 /// `identifier := bare_identifier | string`
 fn identifier(input: &str) -> IResult<&str, String, KdlParseError<&str>> {
-    alt((
-        map(bare_identifier, String::from),
-        string,
-    ))(input)
+    alt((map(bare_identifier, String::from), string))(input)
 }
 
 /// `node-props-and-args := ('/-' ws*)? (prop | value)`

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -112,16 +112,18 @@ pub(crate) fn node(input: &str) -> IResult<&str, Option<KdlNode>, KdlParseError<
     }
 }
 
-/// `identifier := [a-zA-Z_] [a-zA-Z0-9!$%&'*+\-./:<>?@\^_|~]* | string`
+/// `bare_identifier := [a-zA-Z_] [a-zA-Z0-9!$%&'*+\-./:<>?@\^_|~]*`
+pub (crate) fn bare_identifier(input: &str) -> IResult<&str, &str, KdlParseError<&str>> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0(alt((alphanumeric1, recognize(one_of("~!@$%^&*-_+./:<>?"))))),
+    ))(input)
+}
+
+/// `identifier := bare_identifier | string`
 fn identifier(input: &str) -> IResult<&str, String, KdlParseError<&str>> {
     alt((
-        map(
-            recognize(pair(
-                alt((alpha1, tag("_"))),
-                many0(alt((alphanumeric1, recognize(one_of("~!@$%^&*-_+./:<>?"))))),
-            )),
-            String::from,
-        ),
+        map(bare_identifier, String::from),
         string,
     ))(input)
 }


### PR DESCRIPTION
this could definitely be improved, but it's a start?

i wanted a way to print nodes in a way that they could be parsed again

hacks:
- always prints raw strings. counts `"#` patterns so see how much to escape them
- uses identifier parser to see if it should print as identifier or string