### PR TITLE
WIP: Parse comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ edition = "2018"
 
 [dependencies]
 nom = "6.0.1"
+phf = { version = "0.8.0", features = ["macros"] }
 thiserror = "1.0.22"

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,6 +19,13 @@ pub enum KdlValue {
     Null,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum KdlComment {
+    Single,
+    Multiline,
+    SlashDash,
+}
+
 impl fmt::Display for KdlNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.write(f, 0)

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,7 +21,7 @@ pub enum KdlValue {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum KdlComment {
-    Single,
+    Single(String),
     Multiline,
     SlashDash,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,7 @@ pub enum KdlValue {
 #[derive(Debug, Clone, PartialEq)]
 pub enum KdlComment {
     Single(String),
-    Multiline,
+    Multiline(Vec<String>),
     SlashDash,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -112,18 +112,17 @@ pub(crate) fn node(input: &str) -> IResult<&str, Option<KdlNode>, KdlParseError<
     }
 }
 
-/// `identifier := [a-zA-Z_] [a-zA-Z0-9!$%&'*+\-./:<>?@\^_|~]* | string`
-fn identifier(input: &str) -> IResult<&str, String, KdlParseError<&str>> {
-    alt((
-        map(
-            recognize(pair(
-                alt((alpha1, tag("_"))),
-                many0(alt((alphanumeric1, recognize(one_of("~!@$%^&*-_+./:<>?"))))),
-            )),
-            String::from,
-        ),
-        string,
+/// `bare_identifier := [a-zA-Z_] [a-zA-Z0-9!$%&'*+\-./:<>?@\^_|~]*`
+pub(crate) fn bare_identifier(input: &str) -> IResult<&str, &str, KdlParseError<&str>> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0(alt((alphanumeric1, recognize(one_of("~!@$%^&*-_+./:<>?"))))),
     ))(input)
+}
+
+/// `identifier := bare_identifier | string`
+fn identifier(input: &str) -> IResult<&str, String, KdlParseError<&str>> {
+    alt((map(bare_identifier, String::from), string))(input)
 }
 
 /// `node-props-and-args := ('/-' ws*)? (prop | value)`
@@ -197,18 +196,30 @@ fn character(input: &str) -> IResult<&str, char, KdlParseError<&str>> {
     alt((preceded(char('\\'), escape), none_of("\\\"")))(input)
 }
 
+// creates a (map, inverse map) tuple
+macro_rules! bimap {
+    ($($x:expr => $y:expr),+) => {
+        (phf::phf_map!($($x => $y),+), phf::phf_map!($($y => $x),+))
+    }
+}
+
+/// a map and its inverse of escape-sequence<->char
+pub(crate) static ESCAPE_CHARS: (phf::Map<char, char>, phf::Map<char, char>) = bimap! {
+    '"' => '"',
+    '\\' => '\\',
+    '/' => '/',
+    'b' => '\u{08}',
+    'f' => '\u{0C}',
+    'n' => '\n',
+    'r' => '\r',
+    't' => '\t'
+};
+
 /// `escape := ["\\/bfnrt] | 'u{' hex-digit{1, 6} '}'`
 fn escape(input: &str) -> IResult<&str, char, KdlParseError<&str>> {
     alt((
         delimited(tag("u{"), unicode, char('}')),
-        value('"', char('"')),
-        value('\\', char('\\')),
-        value('/', char('/')),
-        value('\u{08}', char('b')),
-        value('\u{0C}', char('f')),
-        value('\n', char('n')),
-        value('\r', char('r')),
-        value('\t', char('t')),
+        map_opt(anychar, |c| ESCAPE_CHARS.0.get(&c).copied()),
     ))(input)
 }
 


### PR DESCRIPTION
This PR starts parsing comments, even though they are not exposed on `KdlNode` or anywhere else.

The reason I need the comments is that I'd like to experiment with a `kdlfmt` binary to consistently layout kdl files at as it stands it would loose the comments.

I am not really sure how to weave the KdlComment in though?
My current thinking is to separating parsing the kdl from parsing the "document":
* `parse` in lib would do return the `Vec<KdlNode>` as is happening today
* `parse_document` in lib would return a `KdlDocument` that is very similar, but accounts for the KdlComments in different places

Does that make sense? If one really wanted, the `parse_document` could be feature flagged too...