### PR TITLE
Fix parsing of non-integer and non-decimal numbers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,11 +258,11 @@ fn raw_string(input: &str) -> IResult<&str, &str, KdlParseError<&str>> {
 /// `number := decimal | hex | octal | binary`
 fn number(input: &str) -> IResult<&str, KdlValue, KdlParseError<&str>> {
     alt((
-        map(integer, KdlValue::Int),
         map(hexadecimal, KdlValue::Int),
         map(octal, KdlValue::Int),
         map(binary, KdlValue::Int),
         map(float, KdlValue::Float),
+        map(integer, KdlValue::Int),
     ))(input)
 }
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -57,6 +57,31 @@ macro_rules! nodes {
     () => { vec![] }
 }
 
+const NUMBERS: &str = r#"
+hex 0x32;
+float 0.5;
+binary 0b0110;
+octal 0o755;
+bignum 1_000_000;
+scientific 1.234e-10;
+"#;
+
+#[test]
+fn test_numbers() {
+    let doc = parse_document(NUMBERS);
+    assert_eq!(
+        doc,
+        Ok(nodes!{
+            hex 0x32;
+            float 0.5;
+            binary 0b0110;
+            octal 0o755;
+            bignum 1_000_000;
+            scientific 1.234e-10;
+        })
+    );
+}
+
 #[test]
 fn test_ci() {
     let doc = parse_document(include_str!("../examples/ci.kdl"));


### PR DESCRIPTION
* Fixes #9 and #10.
* Adds an integration test for all number types
