### PR TITLE
Remove nom dependency on `bitvec` and `lexical`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["kdl", "document", "serialization", "config"]
 edition = "2018"
 
 [dependencies]
-nom = "6.0.1"
+nom = { version = "6.0.1", default-features = false }
 phf = { version = "0.8.0", features = ["macros"] }
 thiserror = "1.0.22"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use crate::node::{KdlNode, KdlValue};
 mod error;
 mod node;
 mod parser;
+mod nom_compat;
 
 pub fn parse_document<I>(input: I) -> Result<Vec<KdlNode>, KdlError>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub use crate::node::{KdlNode, KdlValue};
 
 mod error;
 mod node;
-mod parser;
 mod nom_compat;
+mod parser;
 
 pub fn parse_document<I>(input: I) -> Result<Vec<KdlNode>, KdlError>
 where

--- a/src/nom_compat.rs
+++ b/src/nom_compat.rs
@@ -1,95 +1,100 @@
+use nom::error::{ErrorKind, ParseError};
 use nom::{Err, IResult, Parser};
-use nom::error::{ParseError, ErrorKind};
 
 pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + PartialEq,
-  F: Parser<I, O, E>,
-  E: ParseError<I>,
+    I: Clone + PartialEq,
+    F: Parser<I, O, E>,
+    E: ParseError<I>,
 {
-  move |mut i: I| {
-    let mut acc = Vec::with_capacity(4);
-    loop {
-      match f.parse(i.clone()) {
-        Err(Err::Error(_)) => return Ok((i, acc)),
-        Err(e) => return Err(e),
-        Ok((i1, o)) => {
-          if i1 == i {
-            return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many0)));
-          }
+    move |mut i: I| {
+        let mut acc = Vec::with_capacity(4);
+        loop {
+            match f.parse(i.clone()) {
+                Err(Err::Error(_)) => return Ok((i, acc)),
+                Err(e) => return Err(e),
+                Ok((i1, o)) => {
+                    if i1 == i {
+                        return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many0)));
+                    }
 
-          i = i1;
-          acc.push(o);
+                    i = i1;
+                    acc.push(o);
+                }
+            }
         }
-      }
     }
-  }
 }
 
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + PartialEq,
-  F: Parser<I, O, E>,
-  E: ParseError<I>,
+    I: Clone + PartialEq,
+    F: Parser<I, O, E>,
+    E: ParseError<I>,
 {
-  move |mut i: I| match f.parse(i.clone()) {
-    Err(Err::Error(err)) => Err(Err::Error(E::append(i, ErrorKind::Many1, err))),
-    Err(e) => Err(e),
-    Ok((i1, o)) => {
-      let mut acc = Vec::with_capacity(4);
-      acc.push(o);
-      i = i1;
-
-      loop {
-        match f.parse(i.clone()) {
-          Err(Err::Error(_)) => return Ok((i, acc)),
-          Err(e) => return Err(e),
-          Ok((i1, o)) => {
-            if i1 == i {
-              return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1)));
-            }
-
-            i = i1;
+    move |mut i: I| match f.parse(i.clone()) {
+        Err(Err::Error(err)) => Err(Err::Error(E::append(i, ErrorKind::Many1, err))),
+        Err(e) => Err(e),
+        Ok((i1, o)) => {
+            let mut acc = Vec::with_capacity(4);
             acc.push(o);
-          }
+            i = i1;
+
+            loop {
+                match f.parse(i.clone()) {
+                    Err(Err::Error(_)) => return Ok((i, acc)),
+                    Err(e) => return Err(e),
+                    Ok((i1, o)) => {
+                        if i1 == i {
+                            return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1)));
+                        }
+
+                        i = i1;
+                        acc.push(o);
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 pub fn many_till<I, O, P, E, F, G>(
-  mut f: F,
-  mut g: G,
+    mut f: F,
+    mut g: G,
 ) -> impl FnMut(I) -> IResult<I, (Vec<O>, P), E>
 where
-  I: Clone + PartialEq,
-  F: Parser<I, O, E>,
-  G: Parser<I, P, E>,
-  E: ParseError<I>,
+    I: Clone + PartialEq,
+    F: Parser<I, O, E>,
+    G: Parser<I, P, E>,
+    E: ParseError<I>,
 {
-  move |mut i: I| {
-    let mut res = Vec::new();
-    loop {
-      match g.parse(i.clone()) {
-        Ok((i1, o)) => return Ok((i1, (res, o))),
-        Err(Err::Error(_)) => {
-          match f.parse(i.clone()) {
-            Err(Err::Error(err)) => return Err(Err::Error(E::append(i, ErrorKind::ManyTill, err))),
-            Err(e) => return Err(e),
-            Ok((i1, o)) => {
-              // loop trip must always consume (otherwise infinite loops)
-              if i1 == i {
-                return Err(Err::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
-              }
+    move |mut i: I| {
+        let mut res = Vec::new();
+        loop {
+            match g.parse(i.clone()) {
+                Ok((i1, o)) => return Ok((i1, (res, o))),
+                Err(Err::Error(_)) => {
+                    match f.parse(i.clone()) {
+                        Err(Err::Error(err)) => {
+                            return Err(Err::Error(E::append(i, ErrorKind::ManyTill, err)))
+                        }
+                        Err(e) => return Err(e),
+                        Ok((i1, o)) => {
+                            // loop trip must always consume (otherwise infinite loops)
+                            if i1 == i {
+                                return Err(Err::Error(E::from_error_kind(
+                                    i1,
+                                    ErrorKind::ManyTill,
+                                )));
+                            }
 
-              res.push(o);
-              i = i1;
+                            res.push(o);
+                            i = i1;
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
             }
-          }
         }
-        Err(e) => return Err(e),
-      }
     }
-  }
 }

--- a/src/nom_compat.rs
+++ b/src/nom_compat.rs
@@ -1,0 +1,95 @@
+use nom::{Err, IResult, Parser};
+use nom::error::{ParseError, ErrorKind};
+
+pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+where
+  I: Clone + PartialEq,
+  F: Parser<I, O, E>,
+  E: ParseError<I>,
+{
+  move |mut i: I| {
+    let mut acc = Vec::with_capacity(4);
+    loop {
+      match f.parse(i.clone()) {
+        Err(Err::Error(_)) => return Ok((i, acc)),
+        Err(e) => return Err(e),
+        Ok((i1, o)) => {
+          if i1 == i {
+            return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many0)));
+          }
+
+          i = i1;
+          acc.push(o);
+        }
+      }
+    }
+  }
+}
+
+pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+where
+  I: Clone + PartialEq,
+  F: Parser<I, O, E>,
+  E: ParseError<I>,
+{
+  move |mut i: I| match f.parse(i.clone()) {
+    Err(Err::Error(err)) => Err(Err::Error(E::append(i, ErrorKind::Many1, err))),
+    Err(e) => Err(e),
+    Ok((i1, o)) => {
+      let mut acc = Vec::with_capacity(4);
+      acc.push(o);
+      i = i1;
+
+      loop {
+        match f.parse(i.clone()) {
+          Err(Err::Error(_)) => return Ok((i, acc)),
+          Err(e) => return Err(e),
+          Ok((i1, o)) => {
+            if i1 == i {
+              return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1)));
+            }
+
+            i = i1;
+            acc.push(o);
+          }
+        }
+      }
+    }
+  }
+}
+
+pub fn many_till<I, O, P, E, F, G>(
+  mut f: F,
+  mut g: G,
+) -> impl FnMut(I) -> IResult<I, (Vec<O>, P), E>
+where
+  I: Clone + PartialEq,
+  F: Parser<I, O, E>,
+  G: Parser<I, P, E>,
+  E: ParseError<I>,
+{
+  move |mut i: I| {
+    let mut res = Vec::new();
+    loop {
+      match g.parse(i.clone()) {
+        Ok((i1, o)) => return Ok((i1, (res, o))),
+        Err(Err::Error(_)) => {
+          match f.parse(i.clone()) {
+            Err(Err::Error(err)) => return Err(Err::Error(E::append(i, ErrorKind::ManyTill, err))),
+            Err(e) => return Err(e),
+            Ok((i1, o)) => {
+              // loop trip must always consume (otherwise infinite loops)
+              if i1 == i {
+                return Err(Err::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
+              }
+
+              res.push(o);
+              i = i1;
+            }
+          }
+        }
+        Err(e) => return Err(e),
+      }
+    }
+  }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,8 @@ use nom::character::complete::{anychar, char, none_of, one_of};
 use nom::combinator::{
     all_consuming, eof, iterator, map, map_opt, map_res, not, opt, recognize, value,
 };
-use nom::multi::{fold_many0, many0, many1, many_till};
+use crate::nom_compat::{many0, many1, many_till};
+use nom::multi::fold_many0;
 use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 use nom::Finish;
 use nom::IResult;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, iter::from_fn};
 
+use crate::nom_compat::{many0, many1, many_till};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while_m_n};
 use nom::character::complete::{anychar, char, none_of, one_of};
 use nom::combinator::{
     all_consuming, eof, iterator, map, map_opt, map_res, not, opt, recognize, value,
 };
-use crate::nom_compat::{many0, many1, many_till};
 use nom::multi::fold_many0;
 use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 use nom::Finish;


### PR DESCRIPTION
* Disable all nom features (Resolves #12)
* Copy `many0`/`many1`/`many_till` into `src/nom_compat.rs` (see [this comment](https://github.com/kdl-org/kdl-rs/issues/12#issuecomment-832136758) as to why)

Dependencies before:
<details>
<summary>Click to expand</summary>

```
kdl v1.0.0 (/home/jam/dev/kdl-rs)
├── nom v6.1.2
│   ├── bitvec v0.19.5
│   │   ├── funty v1.1.0
│   │   ├── radium v0.5.3
│   │   ├── tap v1.0.1
│   │   └── wyz v0.2.0
│   ├── funty v1.1.0
│   ├── lexical-core v0.7.6
│   │   ├── arrayvec v0.5.2
│   │   ├── bitflags v1.2.1
│   │   ├── cfg-if v1.0.0
│   │   ├── ryu v1.0.5
│   │   └── static_assertions v1.1.0
│   └── memchr v2.4.0
│   [build-dependencies]
│   └── version_check v0.9.3
├── phf v0.8.0
│   ├── phf_macros v0.8.0 (proc-macro)
│   │   ├── phf_generator v0.8.0
│   │   │   ├── phf_shared v0.8.0
│   │   │   │   └── siphasher v0.3.5
│   │   │   └── rand v0.7.3
│   │   │       ├── getrandom v0.1.16
│   │   │       │   ├── cfg-if v1.0.0
│   │   │       │   └── libc v0.2.94
│   │   │       ├── libc v0.2.94
│   │   │       ├── rand_chacha v0.2.2
│   │   │       │   ├── ppv-lite86 v0.2.10
│   │   │       │   └── rand_core v0.5.1
│   │   │       │       └── getrandom v0.1.16 (*)
│   │   │       ├── rand_core v0.5.1 (*)
│   │   │       └── rand_pcg v0.2.1
│   │   │           └── rand_core v0.5.1 (*)
│   │   ├── phf_shared v0.8.0 (*)
│   │   ├── proc-macro-hack v0.5.19 (proc-macro)
│   │   ├── proc-macro2 v1.0.26
│   │   │   └── unicode-xid v0.2.2
│   │   ├── quote v1.0.9
│   │   │   └── proc-macro2 v1.0.26 (*)
│   │   └── syn v1.0.72
│   │       ├── proc-macro2 v1.0.26 (*)
│   │       ├── quote v1.0.9 (*)
│   │       └── unicode-xid v0.2.2
│   ├── phf_shared v0.8.0 (*)
│   └── proc-macro-hack v0.5.19 (proc-macro)
└── thiserror v1.0.24
    └── thiserror-impl v1.0.24 (proc-macro)
        ├── proc-macro2 v1.0.26 (*)
        ├── quote v1.0.9 (*)
        └── syn v1.0.72 (*)
```
</details>


Dependencies after:
<details>
<summary>Click to expand</summary>

```
kdl v1.0.0 (/home/jam/dev/kdl-rs)
├── nom v6.1.2
│   └── memchr v2.4.0
│   [build-dependencies]
│   └── version_check v0.9.3
├── phf v0.8.0
│   ├── phf_macros v0.8.0 (proc-macro)
│   │   ├── phf_generator v0.8.0
│   │   │   ├── phf_shared v0.8.0
│   │   │   │   └── siphasher v0.3.5
│   │   │   └── rand v0.7.3
│   │   │       ├── getrandom v0.1.16
│   │   │       │   ├── cfg-if v1.0.0
│   │   │       │   └── libc v0.2.94
│   │   │       ├── libc v0.2.94
│   │   │       ├── rand_chacha v0.2.2
│   │   │       │   ├── ppv-lite86 v0.2.10
│   │   │       │   └── rand_core v0.5.1
│   │   │       │       └── getrandom v0.1.16 (*)
│   │   │       ├── rand_core v0.5.1 (*)
│   │   │       └── rand_pcg v0.2.1
│   │   │           └── rand_core v0.5.1 (*)
│   │   ├── phf_shared v0.8.0 (*)
│   │   ├── proc-macro-hack v0.5.19 (proc-macro)
│   │   ├── proc-macro2 v1.0.26
│   │   │   └── unicode-xid v0.2.2
│   │   ├── quote v1.0.9
│   │   │   └── proc-macro2 v1.0.26 (*)
│   │   └── syn v1.0.72
│   │       ├── proc-macro2 v1.0.26 (*)
│   │       ├── quote v1.0.9 (*)
│   │       └── unicode-xid v0.2.2
│   ├── phf_shared v0.8.0 (*)
│   └── proc-macro-hack v0.5.19 (proc-macro)
└── thiserror v1.0.24
    └── thiserror-impl v1.0.24 (proc-macro)
        ├── proc-macro2 v1.0.26 (*)
        ├── quote v1.0.9 (*)
        └── syn v1.0.72 (*)
```
</details>
