### PR TITLE
feat(len): add APIs to calculate component lengths

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -168,6 +168,16 @@ impl KdlDocument {
         self.trailing = Some(trailing.into());
     }
 
+    /// Length of this document when rendered as a string.
+    pub fn len(&self) -> usize {
+        format!("{}", self).len()
+    }
+
+    /// Returns true if this document is completely empty (including whitespace)
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Clears leading and trailing text (whitespace, comments). `KdlNode`s in
     /// this document will be unaffected.
     pub fn clear_fmt(&mut self) {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -98,6 +98,16 @@ impl KdlEntry {
         self.value_repr = Some(repr.into());
     }
 
+    /// Length of this entry when rendered as a string.
+    pub fn len(&self) -> usize {
+        format!("{}", self).len()
+    }
+
+    /// Returns true if this entry is completely empty (including whitespace).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Auto-formats this entry.
     pub fn fmt(&mut self) {
         self.leading = None;

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -31,6 +31,16 @@ impl KdlIdentifier {
         self.repr = Some(repr.into());
     }
 
+    /// Length of this identifier when rendered as a string.
+    pub fn len(&self) -> usize {
+        format!("{}", self).len()
+    }
+
+    /// Returns true if this identifier is completely empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Resets this identifier to its default representation. It will attempt
     /// to make it an unquoted identifier, and fall back to a string
     /// representation if that would be invalid.

--- a/src/node.rs
+++ b/src/node.rs
@@ -106,6 +106,16 @@ impl KdlNode {
         self.trailing = Some(trailing.into());
     }
 
+    /// Length of this node when rendered as a string.
+    pub fn len(&self) -> usize {
+        format!("{}", self).len()
+    }
+
+    /// Returns true if this node is completely empty (including whitespace).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Clears leading and trailing text (whitespace, comments), as well as
     /// the space before the children block, if any. Individual entries and
     /// their formatting will be preserved.


### PR DESCRIPTION
Fixes: https://github.com/kdl-org/kdl-rs/issues/19

This adds some convenience methods that will make #19 _possible_, although it still needs some manual funging, unfortunately. There's no good way to maintain consistent spans across a document, partly due to limitations of how `nom` works, partly because, in practice, they would quickly go out of sync as soon as the `KdlDocument` or any of its components get edited.

So my suggestion is to use these new `len()` APIs to do manual offset calculations in your documents to come up with sensible spans and error messages for the particular failure cases of your KDL-based DSLs. You should then be able to throw the spans you come up with at [`miette`](https://crates.io/crates/miette) to get some nice error message rendering, to boot! :)

Anyway, I hope this helps. It's unfortunate I couldn't come up with something that does more heavy lifting, and I'm always open to accepting patches to allow that, if anyone else ends up having any brilliant ideas on how to get that working right.