### PR TITLE
Add accessors to entry type.

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -49,6 +49,21 @@ impl KdlEntry {
         self.value = value.into();
     }
 
+    /// Gets the entry's type.
+    pub fn ty(&self) -> Option<&KdlIdentifier> {
+        self.ty.as_ref()
+    }
+
+    /// Gets a mutable reference to this entry's type.
+    pub fn ty_mut(&mut self) -> Option<&mut KdlIdentifier> {
+        self.ty.as_mut()
+    }
+
+    /// Sets the entry's type.
+    pub fn set_ty(&mut self, ty: impl Into<KdlIdentifier>) {
+        self.ty = Some(ty.into());
+    }
+
     /// Creates a new Property (key/value) KdlEntry.
     pub fn new_prop(key: impl Into<KdlIdentifier>, value: impl Into<KdlValue>) -> Self {
         KdlEntry {


### PR DESCRIPTION
Hi. Awesome library and markup language! I've been experimenting with it
and I think the `KdlEntry` type accessors were overlooked.

While the type of entries was parsed, there was no way for the library
user to access it. It's part of the spec and I would expect to be able to
read it.