### PR TITLE
Remove reference to Kaydle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ You can think of this crate as
 [`toml_edit`](https://crates.io/crates/toml_edit), but for KDL.
 
 If you don't care about formatting or programmatic manipulation, you might
-check out [`knuffel`](https://crates.io/crates/knuffel) or
-[`kaydle`](https://crates.io/crates/kaydle) instead for serde (or
-serde-like) parsing.
+check out [`knuffel`](https://crates.io/crates/knuffel) instead for serde
+(or serde-like) parsing.
 
 ### Example
 


### PR DESCRIPTION
Closes #42.

Kaydle is an in-development KDL implementation, but it's
not yet ready for use. This commit removes the reference to
it in the interest of not confusing potential users who might
expect it to be ready and be confused by the lack of an
available version on Crates.io.