### PR TITLE
Indent trailing brace of nested nodes.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -513,7 +513,7 @@ impl KdlNode {
                 writeln!(f)?;
             }
             children.stringify(f, indent + 4)?;
-            write!(f, "}}")?;
+            write!(f, "{:indent$}}}", "", indent = indent)?;
         }
         if let Some(trailing) = &self.trailing {
             write!(f, "{}", trailing)?;


### PR DESCRIPTION
In 4.3.0, the Display output for nested nodes always puts the trailing
braces on the left margin:

    a {
        b {
            c {
    }
    }
    }

This commit indents the trailing brace to match the node name, at least
when explicit trailing text is not provided.