### PR TITLE
Fix tests

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
+                }
         }
-    }
 }
 // trailing comment here"#
         );

--- a/src/document.rs
+++ b/src/document.rs
@@ -481,6 +481,25 @@ foo 1 bar=0xdeadbeef {
     }
 
     #[test]
+    fn simple_fmt() -> miette::Result<()> {
+        let mut doc: KdlDocument = "a { b { c { }; }; }".parse().unwrap();
+        KdlDocument::fmt(&mut doc);
+        print!("{}", doc);
+        assert_eq!(
+            doc.to_string(),
+            r#"a {
+    b {
+        c {
+
+        }
+    }
+}
+"#
+        );
+        Ok(())
+    }
+
+    #[test]
     fn parse_examples() -> miette::Result<()> {
         include_str!("../examples/kdl-schema.kdl").parse::<KdlDocument>()?;
         include_str!("../examples/Cargo.kdl").parse::<KdlDocument>()?;

--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
-                }
         }
+    }
 }
 // trailing comment here"#
         );

--- a/src/node.rs
+++ b/src/node.rs
@@ -513,7 +513,7 @@ impl KdlNode {
                 writeln!(f)?;
             }
             children.stringify(f, indent + 4)?;
-            write!(f, "{:indent$}}}", "", indent = indent)?;
+            write!(f, "}}")?;
         }
         if let Some(trailing) = &self.trailing {
             write!(f, "{}", trailing)?;

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,0 +1,27 @@
+use kdl::{KdlDocument, KdlNode, KdlValue};
+
+#[test]
+fn build_and_format() {
+    let mut c = KdlNode::new("c");
+    c.ensure_children();
+    let mut b = KdlNode::new("b");
+    b.ensure_children().nodes_mut().push(c);
+    let mut a = KdlNode::new("a");
+    a.ensure_children().nodes_mut().push(b);
+
+    let mut doc = KdlDocument::new();
+    doc.nodes_mut().push(a);
+    doc.fmt();
+    let fmt = doc.to_string();
+    println!("{fmt}");
+    assert_eq!(
+        fmt,
+        r#"a {
+    b {
+        c {
+}
+}
+}
+"#
+    );
+}


### PR DESCRIPTION
In order,

- Updates the test to pass on main (4ac459a)
- Reverts #49 and the format mangling resulting from it (f820145)
- Adds a new test showing the case in #49 working without #49 (b7fd360)

It might be worthwhile to change how indenting is handled (see e.g. the empty line in the new test), but this is a minimal patch to quickly fix test errors.

cc @cbiffle