### PR TITLE
fmt() should add explicit decoration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ edition = "2021"
 miette = "4.6.0"
 nom = { version = "7.1.1", default-features = false }
 thiserror = "1.0.30"
+
+[dev-dependencies]
+pretty_assertions = "1.2.1"

--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
+                }
         }
-    }
 }
 // trailing comment here"#
         );

--- a/src/document.rs
+++ b/src/document.rs
@@ -481,6 +481,25 @@ foo 1 bar=0xdeadbeef {
     }
 
     #[test]
+    fn simple_fmt() -> miette::Result<()> {
+        let mut doc: KdlDocument = "a { b { c { }; }; }".parse().unwrap();
+        KdlDocument::fmt(&mut doc);
+        print!("{}", doc);
+        assert_eq!(
+            doc.to_string(),
+            r#"a {
+    b {
+        c {
+
+        }
+    }
+}
+"#
+        );
+        Ok(())
+    }
+
+    #[test]
     fn parse_examples() -> miette::Result<()> {
         include_str!("../examples/kdl-schema.kdl").parse::<KdlDocument>()?;
         include_str!("../examples/Cargo.kdl").parse::<KdlDocument>()?;

--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
-                }
         }
+    }
 }
 // trailing comment here"#
         );

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,7 +1,6 @@
+use std::fmt::Write;
+
 pub(crate) fn fmt_leading(leading: &mut String, indent: usize, no_comments: bool) {
-    if leading.is_empty() {
-        return;
-    }
     let mut result = String::new();
     if !no_comments {
         let comments = crate::parser::parse(leading.trim(), crate::parser::leading_comments)
@@ -9,11 +8,11 @@ pub(crate) fn fmt_leading(leading: &mut String, indent: usize, no_comments: bool
         for line in comments {
             let trimmed = line.trim();
             if !trimmed.is_empty() {
-                result.push_str(&format!("{:indent$}{}\n", "", trimmed, indent = indent));
+                writeln!(result, "{:indent$}{trimmed}", "").unwrap();
             }
         }
     }
-    result.push_str(&format!("{:indent$}", "", indent = indent));
+    write!(result, "{:indent$}", "").unwrap();
     *leading = result;
 }
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -26,6 +26,19 @@ impl KdlIdentifier {
         self.repr.as_deref()
     }
 
+    /// Gets the custom string representation for this identifier,
+    /// and starts tracking it if it was not already being tracked.
+    pub fn repr_mut(&mut self) -> &mut String {
+        self.repr = Some(self.repr.take().unwrap_or_else(|| {
+            if self.plain_value() {
+                self.value.clone()
+            } else {
+                format!("{:?}", self.value)
+            }
+        }));
+        self.repr.as_mut().unwrap()
+    }
+
     /// Sets a custom string representation for this identifier.
     pub fn set_repr(&mut self, repr: impl Into<String>) {
         self.repr = Some(repr.into());
@@ -51,12 +64,13 @@ impl KdlIdentifier {
     /// Auto-formats this identifier.
     pub fn fmt(&mut self) {
         self.repr = None;
+        self.repr_mut();
     }
 }
 
 impl Display for KdlIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(repr) = &self.repr {
+        if let Some(repr) = self.repr() {
             write!(f, "{}", repr)
         } else if self.plain_value() {
             write!(f, "{}", self.value)
@@ -169,6 +183,7 @@ impl FromStr for KdlIdentifier {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn parsing() -> miette::Result<()> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -513,7 +513,7 @@ impl KdlNode {
                 writeln!(f)?;
             }
             children.stringify(f, indent + 4)?;
-            write!(f, "{:indent$}}}", "", indent = indent)?;
+            write!(f, "}}")?;
         }
         if let Some(trailing) = &self.trailing {
             write!(f, "{}", trailing)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -638,6 +638,7 @@ fn sign(input: &str) -> IResult<&str, i64, KdlParseError<&str>> {
 #[cfg(test)]
 mod node_tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn basic() {
@@ -684,6 +685,7 @@ mod whitespace_tests {
 #[cfg(test)]
 mod comment_tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn single_line() {
@@ -715,6 +717,7 @@ mod comment_tests {
 #[cfg(test)]
 mod value_tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn boolean_val() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -259,6 +259,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn formatting() {

--- a/tests/compliance.rs
+++ b/tests/compliance.rs
@@ -7,6 +7,8 @@ use std::{
 use kdl::{KdlDocument, KdlError, KdlIdentifier, KdlValue};
 use miette::IntoDiagnostic;
 
+use pretty_assertions::assert_eq;
+
 #[test]
 fn spec_compliance() -> miette::Result<()> {
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,0 +1,27 @@
+use kdl::{KdlDocument, KdlNode, KdlValue};
+
+#[test]
+fn build_and_format() {
+    let mut c = KdlNode::new("c");
+    c.ensure_children();
+    let mut b = KdlNode::new("b");
+    b.ensure_children().nodes_mut().push(c);
+    let mut a = KdlNode::new("a");
+    a.ensure_children().nodes_mut().push(b);
+
+    let mut doc = KdlDocument::new();
+    doc.nodes_mut().push(a);
+    doc.fmt();
+    let fmt = doc.to_string();
+    println!("{fmt}");
+    assert_eq!(
+        fmt,
+        r#"a {
+    b {
+        c {
+}
+}
+}
+"#
+    );
+}

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,27 +1,42 @@
-use kdl::{KdlDocument, KdlNode, KdlValue};
+use kdl::{KdlDocument, KdlNode};
 
-#[test]
-fn build_and_format() {
+use pretty_assertions::assert_eq;
+
+fn build_abc() -> KdlDocument {
     let mut c = KdlNode::new("c");
     c.ensure_children();
     let mut b = KdlNode::new("b");
     b.ensure_children().nodes_mut().push(c);
     let mut a = KdlNode::new("a");
     a.ensure_children().nodes_mut().push(b);
-
     let mut doc = KdlDocument::new();
     doc.nodes_mut().push(a);
     doc.fmt();
-    let fmt = doc.to_string();
-    println!("{fmt}");
+    doc
+}
+
+#[test]
+fn build_and_format() {
+    let fmt = build_abc().to_string();
     assert_eq!(
         fmt,
         r#"a {
     b {
         c {
-}
-}
+
+        }
+    }
 }
 "#
     );
+}
+
+#[test]
+fn build_and_parse() -> miette::Result<()> {
+    let mut built = build_abc();
+    let mut parsed: KdlDocument = build_abc().to_string().parse()?;
+    built.fmt();
+    parsed.fmt();
+    assert_eq!(built, parsed);
+    Ok(())
 }


### PR DESCRIPTION
Closes #53 (built on top of it), closes #54 

This PR takes the approach that calling `fmt` should always fully fill in the `leading`/`trailing` fields to be explicit. A separate approach to fix #54 and fix formatting of built nodes is to fix the `None` formatting... which should still be done, ideally, but this is the approach that came more easily.

cc @cbiffle 