### PR TITLE
Fix formatting when decoration is not present

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
+                }
         }
-    }
 }
 // trailing comment here"#
         );

--- a/src/document.rs
+++ b/src/document.rs
@@ -481,6 +481,25 @@ foo 1 bar=0xdeadbeef {
     }
 
     #[test]
+    fn simple_fmt() -> miette::Result<()> {
+        let mut doc: KdlDocument = "a { b { c { }; }; }".parse().unwrap();
+        KdlDocument::fmt(&mut doc);
+        print!("{}", doc);
+        assert_eq!(
+            doc.to_string(),
+            r#"a {
+    b {
+        c {
+
+        }
+    }
+}
+"#
+        );
+        Ok(())
+    }
+
+    #[test]
     fn parse_examples() -> miette::Result<()> {
         include_str!("../examples/kdl-schema.kdl").parse::<KdlDocument>()?;
         include_str!("../examples/Cargo.kdl").parse::<KdlDocument>()?;

--- a/src/document.rs
+++ b/src/document.rs
@@ -472,8 +472,8 @@ foo 1 bar=0xdeadbeef {
         inner1 r"value"
         inner2 {
             inner3
-                }
         }
+    }
 }
 // trailing comment here"#
         );

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 pub(crate) fn fmt_leading(leading: &mut String, indent: usize, no_comments: bool) {
     if leading.is_empty() {
         return;
@@ -9,11 +11,11 @@ pub(crate) fn fmt_leading(leading: &mut String, indent: usize, no_comments: bool
         for line in comments {
             let trimmed = line.trim();
             if !trimmed.is_empty() {
-                result.push_str(&format!("{:indent$}{}\n", "", trimmed, indent = indent));
+                writeln!(result, "{:indent$}{}", "", trimmed, indent = indent).unwrap();
             }
         }
     }
-    result.push_str(&format!("{:indent$}", "", indent = indent));
+    write!(result, "{:indent$}", "", indent = indent).unwrap();
     *leading = result;
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -369,7 +369,7 @@ impl KdlNode {
 }
 
 /// Represents a [`KdlNode`]'s entry key.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeKey {
     /// Key for a node property entry.
     Key(KdlIdentifier),

--- a/src/node.rs
+++ b/src/node.rs
@@ -513,6 +513,9 @@ impl KdlNode {
                 writeln!(f)?;
             }
             children.stringify(f, indent + 4)?;
+            if children.trailing.is_none() {
+                write!(f, "{:indent$}", "", indent = indent)?;
+            }
             write!(f, "}}")?;
         }
         if let Some(trailing) = &self.trailing {

--- a/src/node.rs
+++ b/src/node.rs
@@ -513,7 +513,7 @@ impl KdlNode {
                 writeln!(f)?;
             }
             children.stringify(f, indent + 4)?;
-            write!(f, "{:indent$}}}", "", indent = indent)?;
+            write!(f, "}}")?;
         }
         if let Some(trailing) = &self.trailing {
             write!(f, "{}", trailing)?;

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,0 +1,27 @@
+use kdl::{KdlDocument, KdlNode, KdlValue};
+
+#[test]
+fn build_and_format() {
+    let mut c = KdlNode::new("c");
+    c.ensure_children();
+    let mut b = KdlNode::new("b");
+    b.ensure_children().nodes_mut().push(c);
+    let mut a = KdlNode::new("a");
+    a.ensure_children().nodes_mut().push(b);
+
+    let mut doc = KdlDocument::new();
+    doc.nodes_mut().push(a);
+    doc.fmt();
+    let fmt = doc.to_string();
+    println!("{fmt}");
+    assert_eq!(
+        fmt,
+        r#"a {
+    b {
+        c {
+}
+}
+}
+"#
+    );
+}

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -13,7 +13,7 @@ fn build_and_format() {
     doc.nodes_mut().push(a);
     doc.fmt();
     let fmt = doc.to_string();
-    println!("{fmt}");
+    println!("{}", fmt);
     assert_eq!(
         fmt,
         r#"a {

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,4 +1,4 @@
-use kdl::{KdlDocument, KdlNode, KdlValue};
+use kdl::{KdlDocument, KdlNode};
 
 #[test]
 fn build_and_format() {
@@ -19,8 +19,8 @@ fn build_and_format() {
         r#"a {
     b {
         c {
-}
-}
+        }
+    }
 }
 "#
     );


### PR DESCRIPTION
A lot easier than #55, actually

Includes/closes #53; redoes #49 properly, subsumes/closes #50

cc @cbiffle one last time