### PR TITLE
add spans to a bunch of things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/kdl-org/kdl-rs"
 keywords = ["kdl", "document", "serialization", "config"]
 edition = "2021"
 
+[features]
+default = ["span"]
+span = []
+
 [dependencies]
 miette = "5.3.0"
 nom = { version = "7.1.1", default-features = false }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -6,7 +6,10 @@ pub(crate) fn fmt_leading(leading: &mut String, indent: usize, no_comments: bool
     }
     let mut result = String::new();
     if !no_comments {
-        let comments = crate::parser::parse(leading.trim(), crate::parser::leading_comments)
+        let input = leading.trim();
+        let kdl_parser = crate::parser::KdlParser { full_input: input };
+        let comments = kdl_parser
+            .parse(crate::parser::leading_comments(&kdl_parser))
             .expect("invalid leading text");
         for line in comments {
             let trimmed = line.trim();
@@ -26,7 +29,10 @@ pub(crate) fn fmt_trailing(decor: &mut String, no_comments: bool) {
     *decor = decor.trim().to_string();
     let mut result = String::new();
     if !no_comments {
-        let comments = crate::parser::parse(decor, crate::parser::trailing_comments)
+        let input = &*decor;
+        let kdl_parser = crate::parser::KdlParser { full_input: input };
+        let comments = kdl_parser
+            .parse(crate::parser::trailing_comments(&kdl_parser))
             .expect("invalid trailing text");
         for comment in comments {
             result.push_str(comment);


### PR DESCRIPTION
This necessitates passing the input around through all the sub-parsers so they
can compute their own sub-spans, which in turn necessitates making most of the
subparsers into nom-style 'function builders' by wrapping them in closures and
returning the closures.

The current impl tentatively hides this functionality behind an on-by-default
feature, but the cfging isn't complete, as things got messy enough that I
decided to start ignoring it while I dealt with the main functionality.

Tests currently fail because the derived Eq impls now see the spans, making
an item parsed from the middle of a string different from an ident parsed
from the start of one.