### PR TITLE
rework the span API to be strictly by-val

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -60,14 +60,8 @@ impl KdlDocument {
     /// but may become invalidated if the document is mutated. We do not currently
     /// guarantee this to yield any particularly consistent results at that point.
     #[cfg(feature = "span")]
-    pub fn span(&self) -> &SourceSpan {
-        &self.span
-    }
-
-    /// Gets a mutable reference to this document's span.
-    #[cfg(feature = "span")]
-    pub fn span_mut(&mut self) -> &mut SourceSpan {
-        &mut self.span
+    pub fn span(&self) -> SourceSpan {
+        self.span
     }
 
     /// Sets this document's span.
@@ -593,8 +587,8 @@ foo 1 bar=0xdeadbeef {
 
     #[cfg(feature = "span")]
     #[track_caller]
-    fn check_span(expected: &str, span: &SourceSpan, source: &impl miette::SourceCode) {
-        let span = source.read_span(span, 0, 0).unwrap();
+    fn check_span(expected: &str, span: SourceSpan, source: &impl miette::SourceCode) {
+        let span = source.read_span(&span, 0, 0).unwrap();
         let span = std::str::from_utf8(span.data()).unwrap();
         assert_eq!(span, expected);
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -73,14 +73,8 @@ impl KdlEntry {
     /// but may become invalidated if the document is mutated. We do not currently
     /// guarantee this to yield any particularly consistent results at that point.
     #[cfg(feature = "span")]
-    pub fn span(&self) -> &SourceSpan {
-        &self.span
-    }
-
-    /// Gets a mutable reference to this entry's span.
-    #[cfg(feature = "span")]
-    pub fn span_mut(&mut self) -> &mut SourceSpan {
-        &mut self.span
+    pub fn span(&self) -> SourceSpan {
+        self.span
     }
 
     /// Sets this entry's span.

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -46,14 +46,8 @@ impl KdlIdentifier {
     /// but may become invalidated if the document is mutated. We do not currently
     /// guarantee this to yield any particularly consistent results at that point.
     #[cfg(feature = "span")]
-    pub fn span(&self) -> &SourceSpan {
-        &self.span
-    }
-
-    /// Gets a mutable reference to this identifier's span.
-    #[cfg(feature = "span")]
-    pub fn span_mut(&mut self) -> &mut SourceSpan {
-        &mut self.span
+    pub fn span(&self) -> SourceSpan {
+        self.span
     }
 
     /// Sets this identifier's span.

--- a/src/node.rs
+++ b/src/node.rs
@@ -76,14 +76,8 @@ impl KdlNode {
     /// but may become invalidated if the document is mutated. We do not currently
     /// guarantee this to yield any particularly consistent results at that point.
     #[cfg(feature = "span")]
-    pub fn span(&self) -> &SourceSpan {
-        &self.span
-    }
-
-    /// Gets a mutable reference to this node's span.
-    #[cfg(feature = "span")]
-    pub fn span_mut(&mut self) -> &mut SourceSpan {
-        &mut self.span
+    pub fn span(&self) -> SourceSpan {
+        self.span
     }
 
     /// Sets this node's span.


### PR DESCRIPTION
This is my own fault, I should have anticipated it. Spans are extremely POD and don't really have any place being passed around by-ref. It's annoying to have to deref them all over the place!

By storing them by-val we also give ourselves room to make many "reasonable" optimizations to compress spans, as we don't need to *actually* store them in that exact form.

If you accept this PR it would be a breaking change but to an API recently added that I'm probably the only user for. I would 100% understand "nah you got your shot and messed it up, live with the implications".