### PR TITLE
chore: update link to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You must be at least `1.70.0` tall to get on this ride.
 ### License
 
 The code in this repository is covered by [the Apache-2.0
-License](LICENSE.md).
+License](LICENSE).
 
 [`KdlDocument`]: https://docs.rs/kdl/latest/kdl/struct.KdlDocument.html
 [`KdlNode`]: https://docs.rs/kdl/latest/kdl/struct.KdlNode.html

--- a/examples/Cargo.kdl
+++ b/examples/Cargo.kdl
@@ -3,7 +3,7 @@ package {
     version "0.0.0"
     description "The kdl document language"
     authors "Kat Marchán <kzm@zkat.tech>"
-    license-file LICENSE.md
+    license-file LICENSE
     edition "2018"
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@
 //! ## License
 //!
 //! The code in this repository is covered by [the Apache-2.0
-//! License](LICENSE.md).
+//! License](LICENSE).
 
 // TODO(@zkat): bring this back later.
 // ### Query Engine


### PR DESCRIPTION
the file has been renamed in 0dbf75c78eb918b6966aae27fb1d7591791f15de