### PR TITLE
Configurable autoformat with `FormatConfig`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ default = ["span"]
 span = []
 
 [dependencies]
-bon = { version = "2.1.0", default-features = false } # 3.2.0 requires rustc 1.59.0
 miette = "7.2.0"
 num = "0.4.2"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["span"]
 span = []
 
 [dependencies]
+bon = { version = "2.1.0", default-features = false } # 3.2.0 requires rustc 1.59.0
 miette = "7.2.0"
 num = "0.4.2"
 thiserror = "1.0.40"

--- a/src/document.rs
+++ b/src/document.rs
@@ -692,7 +692,10 @@ foo 1 bar=0xdeadbeef {
 
     #[test]
     fn simple_autoformat_no_comments() -> miette::Result<()> {
-        let mut doc: KdlDocument = "// a comment\na {\n// another comment\n b { c { // another comment\n }; }; }".parse().unwrap();
+        let mut doc: KdlDocument =
+            "// a comment\na {\n// another comment\n b { c { // another comment\n }; }; }"
+                .parse()
+                .unwrap();
         KdlDocument::autoformat_no_comments(&mut doc);
         assert_eq!(
             doc.to_string(),

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,20 +3,17 @@ use std::fmt::Write as _;
 /// Formatting configuration for use with [`KdlDocument::autoformat_config`](`crate::KdlDocument::autoformat_config`)
 /// and [`KdlNode::autoformat_config`](`crate::KdlNode::autoformat_config`).
 #[non_exhaustive]
-#[derive(Debug, bon::Builder)]
+#[derive(Debug)]
 pub struct FormatConfig<'a> {
     /// How deeply to indent the overall node or document,
     /// in repetitions of [`indent`](`FormatConfig::indent`).
     /// Defaults to `0`.
-    #[builder(default = 0)]
     pub indent_level: usize,
 
     /// The indentation to use at each level. Defaults to four spaces.
-    #[builder(default = "    ")]
     pub indent: &'a str,
 
     /// Whether to remove comments. Defaults to `false`.
-    #[builder(default = false)]
     pub no_comments: bool,
 }
 
@@ -24,6 +21,89 @@ pub struct FormatConfig<'a> {
 impl Default for FormatConfig<'_> {
     fn default() -> Self {
         Self::builder().build()
+    }
+}
+
+impl FormatConfig<'_> {
+    /// Creates a new [`FormatConfigBuilder`] with default configuration.
+    pub const fn builder() -> FormatConfigBuilder<'static> {
+        FormatConfigBuilder::new()
+    }
+}
+
+/// A [`FormatConfig`] builder.
+///
+/// Note that setters can be repeated.
+#[derive(Debug, Default)]
+pub struct FormatConfigBuilder<'a>(FormatConfig<'a>);
+
+impl<'a> FormatConfigBuilder<'a> {
+    /// Creates a new [`FormatConfig`] builder with default configuration.
+    pub const fn new() -> Self {
+        FormatConfigBuilder(FormatConfig {
+            indent_level: 0,
+            indent: "    ",
+            no_comments: false,
+        })
+    }
+
+    /// How deeply to indent the overall node or document,
+    /// in repetitions of [`indent`](`FormatConfig::indent`).
+    /// Defaults to `0` iff not specified.
+    pub const fn maybe_indent_level(mut self, indent_level: Option<usize>) -> Self {
+        if let Some(indent_level) = indent_level {
+            self.0.indent_level = indent_level;
+        }
+        self
+    }
+
+    /// How deeply to indent the overall node or document,
+    /// in repetitions of [`indent`](`FormatConfig::indent`).
+    /// Defaults to `0` iff not specified.
+    pub const fn indent_level(mut self, indent_level: usize) -> Self {
+        self.0.indent_level = indent_level;
+        self
+    }
+
+    /// The indentation to use at each level.
+    /// Defaults to four spaces iff not specified.
+    pub const fn maybe_indent<'b, 'c>(self, indent: Option<&'b str>) -> FormatConfigBuilder<'c>
+    where
+        'a: 'b,
+        'b: 'c,
+    {
+        if let Some(indent) = indent {
+            self.indent(indent)
+        } else {
+            self
+        }
+    }
+
+    /// The indentation to use at each level.
+    /// Defaults to four spaces if not specified.
+    pub const fn indent<'b>(self, indent: &'b str) -> FormatConfigBuilder<'b> {
+        FormatConfigBuilder(FormatConfig { indent, ..self.0 })
+    }
+
+    /// Whether to remove comments.
+    /// Defaults to `false` iff not specified.
+    pub const fn maybe_no_comments(mut self, no_comments: Option<bool>) -> Self {
+        if let Some(no_comments) = no_comments {
+            self.0.no_comments = no_comments;
+        }
+        self
+    }
+
+    /// Whether to remove comments.
+    /// Defaults to `false` iff not specified.
+    pub const fn no_comments(mut self, no_comments: bool) -> Self {
+        self.0.no_comments = no_comments;
+        self
+    }
+
+    /// Builds the [`FormatConfig`].
+    pub const fn build(self) -> FormatConfig<'a> {
+        self.0
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,19 +1,52 @@
 use std::fmt::Write as _;
 
-pub(crate) fn autoformat_leading(leading: &mut String, indent: usize, no_comments: bool) {
+/// Formatting configuration for use with [`KdlDocument::autoformat_config`](`crate::KdlDocument::autoformat_config`)
+/// and [`KdlNode::autoformat_config`](`crate::KdlNode::autoformat_config`).
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct FormatConfig<'a> {
+    /// How deeply to indent the overall node or document,
+    /// in repetitions of [`indent`](`FormatConfig::indent`).
+    /// Defaults to `0`.
+    pub indent_level: usize,
+
+    /// The indentation to use at each level. Defaults to four spaces.
+    pub indent: &'a str,
+
+    /// Whether to remove comments. Defaults to `false`.
+    pub no_comments: bool,
+}
+
+/// See field documentation for defaults.
+impl Default for FormatConfig<'_> {
+    fn default() -> Self {
+        Self {
+            indent_level: 0,
+            indent: "    ",
+            no_comments: false,
+        }
+    }
+}
+
+pub(crate) fn autoformat_leading(leading: &mut String, config: &FormatConfig<'_>) {
     let mut result = String::new();
-    if !no_comments {
+    if !config.no_comments {
         let input = leading.trim();
         if !input.is_empty() {
             for line in input.lines() {
                 let trimmed = line.trim();
                 if !trimmed.is_empty() {
-                    writeln!(result, "{:indent$}{}", "", trimmed, indent = indent).unwrap();
+                    for _ in 0..config.indent_level {
+                        result.push_str(config.indent);
+                    }
+                    writeln!(result, "{}", trimmed).unwrap();
                 }
             }
         }
     }
-    write!(result, "{:indent$}", "", indent = indent).unwrap();
+    for _ in 0..config.indent_level {
+        result.push_str(config.indent);
+    }
     *leading = result;
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,28 +3,27 @@ use std::fmt::Write as _;
 /// Formatting configuration for use with [`KdlDocument::autoformat_config`](`crate::KdlDocument::autoformat_config`)
 /// and [`KdlNode::autoformat_config`](`crate::KdlNode::autoformat_config`).
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, bon::Builder)]
 pub struct FormatConfig<'a> {
     /// How deeply to indent the overall node or document,
     /// in repetitions of [`indent`](`FormatConfig::indent`).
     /// Defaults to `0`.
+    #[builder(default = 0)]
     pub indent_level: usize,
 
     /// The indentation to use at each level. Defaults to four spaces.
+    #[builder(default = "    ")]
     pub indent: &'a str,
 
     /// Whether to remove comments. Defaults to `false`.
+    #[builder(default = false)]
     pub no_comments: bool,
 }
 
 /// See field documentation for defaults.
 impl Default for FormatConfig<'_> {
     fn default() -> Self {
-        Self {
-            indent_level: 0,
-            indent: "    ",
-            no_comments: false,
-        }
+        Self::builder().build()
     }
 }
 
@@ -65,4 +64,27 @@ pub(crate) fn autoformat_trailing(decor: &mut String, no_comments: bool) {
         }
     }
     *decor = result;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn builder() -> miette::Result<()> {
+        let built = FormatConfig::builder()
+            .indent_level(12)
+            .indent(" \t")
+            .no_comments(true)
+            .build();
+        assert!(matches!(
+            built,
+            FormatConfig {
+                indent_level: 12,
+                indent: " \t",
+                no_comments: true,
+            }
+        ));
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@
 pub use document::*;
 pub use entry::*;
 pub use error::*;
+pub use fmt::*;
 pub use identifier::*;
 pub use node::*;
 // pub use query::*;


### PR DESCRIPTION
This implements the discussion in #85, i.e. `(KdlDocument|KdlNode)::autoformat_config(&mut self, config: &FormatConfig)` (replacing the respective internal `autoformat_impl` functions), with small changes to the `FormatConfig` fields.

The first commit adds just the configurable formatting with tests, the second one adds a builder API to `FormatConfig`.