### PR TITLE
Enable span properly to fix build failure with `span` feature disabled

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -580,7 +580,10 @@ mod test {
 
         let entry: KdlEntry = " \\\n (\"m\\\"eh\")0xDEADbeef\t\\\n".parse()?;
         let mut ty: KdlIdentifier = "\"m\\\"eh\"".parse()?;
-        ty.span = (5..12).into();
+        #[cfg(feature = "span")]
+        {
+            ty.span = (5..12).into();
+        }
         assert_eq!(
             entry,
             KdlEntry {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -579,27 +579,30 @@ mod test {
         );
 
         let entry: KdlEntry = " \\\n (\"m\\\"eh\")0xDEADbeef\t\\\n".parse()?;
-        let mut ty: KdlIdentifier = "\"m\\\"eh\"".parse()?;
-        #[cfg(feature = "span")]
+        #[cfg_attr(not(feature = "span"), allow(unused_mut))]
         {
-            ty.span = (5..12).into();
-        }
-        assert_eq!(
-            entry,
-            KdlEntry {
-                ty: Some(ty),
-                value: KdlValue::Integer(0xdeadbeef),
-                name: None,
-                format: Some(KdlEntryFormat {
-                    leading: " \\\n ".into(),
-                    trailing: "\t\\\n".into(),
-                    value_repr: "0xDEADbeef".into(),
-                    ..Default::default()
-                }),
-                #[cfg(feature = "span")]
-                span: SourceSpan::from(0..26),
+            let mut ty: KdlIdentifier = "\"m\\\"eh\"".parse()?;
+            #[cfg(feature = "span")]
+            {
+                ty.span = (5..12).into();
             }
-        );
+            assert_eq!(
+                entry,
+                KdlEntry {
+                    ty: Some(ty),
+                    value: KdlValue::Integer(0xdeadbeef),
+                    name: None,
+                    format: Some(KdlEntryFormat {
+                        leading: " \\\n ".into(),
+                        trailing: "\t\\\n".into(),
+                        value_repr: "0xDEADbeef".into(),
+                        ..Default::default()
+                    }),
+                    #[cfg(feature = "span")]
+                    span: SourceSpan::from(0..26),
+                }
+            );
+        }
 
         let entry: KdlEntry = " \\\n \"foo\"=(\"m\\\"eh\")0xDEADbeef\t\\\n".parse()?;
         assert_eq!(

--- a/src/v2_parser.rs
+++ b/src/v2_parser.rs
@@ -759,6 +759,7 @@ fn node_children(input: &mut Input<'_>) -> PResult<KdlDocument> {
             .map(|_| KdlDocument::new())
             .or_else(|mut e: ErrMode<KdlParseError>| {
                 e = match e {
+                    #[cfg_attr(not(feature = "span"), allow(unused_mut))]
                     ErrMode::Cut(mut pe) => {
                         #[cfg(feature = "span")]
                         {

--- a/src/v2_parser.rs
+++ b/src/v2_parser.rs
@@ -759,12 +759,8 @@ fn node_children(input: &mut Input<'_>) -> PResult<KdlDocument> {
             .map(|_| KdlDocument::new())
             .or_else(|mut e: ErrMode<KdlParseError>| {
                 e = match e {
-                    #[cfg_attr(not(feature = "span"), allow(unused_mut))]
                     ErrMode::Cut(mut pe) => {
-                        #[cfg(feature = "span")]
-                        {
-                            pe.span = Some((_before_open_loc.._after_open_loc).into());
-                        }
+                        pe.span = Some((_before_open_loc.._after_open_loc).into());
                         ErrMode::Cut(pe)
                     }
                     e => return Err(e),

--- a/src/v2_parser.rs
+++ b/src/v2_parser.rs
@@ -439,11 +439,13 @@ fn test_node() {
             name: KdlIdentifier {
                 value: "foo".into(),
                 repr: Some("foo".into()),
+                #[cfg(feature = "span")]
                 span: (0..3).into()
             },
             entries: vec![],
             children: None,
             format: Some(Default::default()),
+            #[cfg(feature = "span")]
             span: (0..7).into()
         }
     );
@@ -455,6 +457,7 @@ fn test_node() {
             name: KdlIdentifier {
                 value: "foo".into(),
                 repr: Some("foo".into()),
+                #[cfg(feature = "span")]
                 span: (0..3).into()
             },
             entries: vec![KdlEntry {
@@ -466,12 +469,14 @@ fn test_node() {
                     leading: " ".into(),
                     ..Default::default()
                 }),
+                #[cfg(feature = "span")]
                 span: SourceSpan::new(3.into(), 4)
             }],
             children: None,
             format: Some(KdlNodeFormat {
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (0..8).into()
         }
     );
@@ -552,7 +557,6 @@ fn node_entry(input: &mut Input<'_>) -> PResult<Option<KdlEntry>> {
                 fmt.after_key = after_key.into();
                 fmt.after_eq = after_eq.into();
             }
-            #[cfg(feature = "span")]
             value
         })
     } else if let Some(ident) = maybe_ident {
@@ -607,6 +611,7 @@ fn entry_test() {
                 value_repr: "bar".into(),
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (0..7).into()
         })
     );
@@ -621,6 +626,7 @@ fn entry_test() {
                 value_repr: "foo".into(),
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (0..3).into()
         })
     );
@@ -636,6 +642,7 @@ fn entry_test() {
                 leading: "/-foo ".into(),
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (6..9).into()
         })
     );
@@ -648,6 +655,7 @@ fn entry_test() {
             name: Some(KdlIdentifier {
                 value: "bar".into(),
                 repr: Some("bar".into()),
+                #[cfg(feature = "span")]
                 span: (9..12).into(),
             }),
             format: Some(KdlEntryFormat {
@@ -657,6 +665,7 @@ fn entry_test() {
                 after_eq: " ".into(),
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (9..16).into()
         })
     );
@@ -669,6 +678,7 @@ fn entry_test() {
             name: Some(KdlIdentifier {
                 value: "bar".into(),
                 repr: Some("bar".into()),
+                #[cfg(feature = "span")]
                 span: (12..16).into(),
             }),
             format: Some(KdlEntryFormat {
@@ -678,6 +688,7 @@ fn entry_test() {
                 after_eq: " ".into(),
                 ..Default::default()
             }),
+            #[cfg(feature = "span")]
             span: (12..18).into()
         })
     );
@@ -1508,6 +1519,7 @@ mod string_tests {
             KdlIdentifier {
                 value: "foo".into(),
                 repr: Some("foo".into()),
+                #[cfg(feature = "span")]
                 span: (0..3).into()
             }
         );
@@ -1516,6 +1528,7 @@ mod string_tests {
             KdlIdentifier {
                 value: "+.".into(),
                 repr: Some("+.".into()),
+                #[cfg(feature = "span")]
                 span: (0..1).into()
             }
         )


### PR DESCRIPTION
# Summary

* Fix build error when `span` feature is disabled (due to `--no-default-features` (`cargo` CLI) or `default-features = false` (Cargo.toml)).
* Set error span correctly even when `span` feature is disabled.
    + This fixes `v2_parser::failure_tests::bad_child_test` failure with `span` feature disabled.

# How to reproduce
1. Check out `kdl-rs` repository
    + main branch or the latest release (v6.3.3)
    + Older versions may also be affected, but I didn't check.
2. Run `cargo check --no-default-features`
3. You'll see build error.

```
$ cargo check --no-default-features
    Checking kdl v6.3.3 (/tmp/kdl2/kdl-rs)
error[E0308]: `if` and `else` have incompatible types
   --> src/v2_parser.rs:558:12
    |
543 |         let entry = if let Some(after_key) = after_key {
    |  ___________________-
544 | |           let (after_eq, value) = (
545 | |               node_space0.take(),
546 | |               cut_err(value.context(cx().lbl("property value"))),
...   |
549 | | /         value.map(|mut value| {
550 | | |             value.name = maybe_ident;
551 | | |             if let Some(fmt) = value.format_mut() {
552 | | |                 fmt.after_key = after_key.into();
...   | |
556 | | |             value
557 | | |         })
    | | |__________- expected because of this
558 | |       } else if let Some(ident) = maybe_ident {
    | |  ____________^
559 | | |         // It was ambiguous, but this ident is actually a value.
560 | | |         Some(KdlEntry {
561 | | |             format: Some(KdlEntryFormat {
...   | |
574 | | |             .flatten()
575 | | |     };
    | | |     ^
    | |_|_____|
    |   |_____`if` and `else` have incompatible types
    |         expected `Option<()>`, found `Option<KdlEntry>`
    |
    = note: expected enum `Option<()>`
               found enum `Option<entry::KdlEntry>`

warning: variable does not need to be mutable
   --> src/v2_parser.rs:751:34
    |
751 |                     ErrMode::Cut(mut pe) => {
    |                                  ----^^
    |                                  |
    |                                  help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

For more information about this error, try `rustc --explain E0308`.
warning: `kdl` (lib) generated 1 warning
error: could not compile `kdl` (lib) due to 1 previous error; 1 warning emitted
$
```