### PR TITLE
docs: Fix version number in KdlDocument::v2_to_v1

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -390,7 +390,7 @@ impl KdlDocument {
     }
 
     /// Takes a KDL v2 document string and returns the same document, but
-    /// autoformatted into valid KDL v2 syntax.
+    /// autoformatted into valid KDL v1 syntax.
     #[cfg(feature = "v1")]
     pub fn v2_to_v1(s: &str) -> Result<String, KdlError> {
         let mut doc = KdlDocument::parse_v2(s)?;


### PR DESCRIPTION
I think that this doc comment didn't get fully updated, and that instead of saying it is formats a v2 document into v2 syntax, it means a v2 document into v1 syntax.