### PR TITLE
Mention comments and whitespace in `format` accessors

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -193,7 +193,7 @@ impl KdlDocument {
         &mut self.nodes
     }
 
-    /// Gets the formatting details for this entry.
+    /// Gets the formatting details (including whitespace and comments) for this entry.
     pub fn format(&self) -> Option<&KdlDocumentFormat> {
         self.format.as_ref()
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -112,7 +112,7 @@ impl KdlEntry {
         self.ty = Some(ty.into());
     }
 
-    /// Gets the formatting details for this entry.
+    /// Gets the formatting details (including whitespace and comments) for this entry.
     pub fn format(&self) -> Option<&KdlEntryFormat> {
         self.format.as_ref()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -246,7 +246,7 @@ impl KdlNode {
         self.children_mut().as_mut().unwrap()
     }
 
-    /// Gets the formatting details for this node.
+    /// Gets the formatting details (including whitespace and comments) for this node.
     pub fn format(&self) -> Option<&KdlNodeFormat> {
         self.format.as_ref()
     }


### PR DESCRIPTION
In https://github.com/kdl-org/kdl/discussions/68#discussioncomment-12736183, I totally missed that it was already possible to access comments, even after looking through the docs.

I think I searched for "comments" on the docs, without looking deeply enough into the `Format` types and `format` accessors realizing that the data was already there.

Added a name drop of comments and whitespace on all of the `format` accessors, to make it easier to find for other folks that aren't as familiar with the API, like I wasn't.

If there's a better way you can think of highlighting this, happy to do so.

Thanks again for helping me realize it was already supported :)