### PR TITLE
Commit Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-Cargo.lock


### PR DESCRIPTION
As I was trying to package `kdl-lsp` for Nix, I realized that this project currently does not commit its `Cargo.lock`.

As per the [Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html), it is considered best practice to have the lock file under version control. ("When in doubt, check Cargo.lock into the version control system (e.g. Git)")

I tried to search throughout this repository (in issues, discussions and documentation) whether this had been discussed before, but my cursory search did not yield anything.

Is there a reason for this choice? If so, perhaps documenting it would be best.