### PR TITLE
Relax winnow version constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = ["tools/*"]
 [dependencies]
 miette.workspace = true
 num = "0.4.2"
-winnow = { version = "=0.6.24", features = ["alloc", "unstable-recover"] }
+winnow = { version = "0.6.24", features = ["alloc", "unstable-recover"] }
 kdlv1 = { package = "kdl", version = "4.7.0", optional = true }
 
 [workspace.dependencies]


### PR DESCRIPTION
Change winnow dependency from `version = "=0.6.24"` to `version = "0.6.24"`.

I saw that this constraint was added in #119, so it must be for good reason. I was curious about what that reason was?

