### PR TITLE
Assign document leading format to the first node instead

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -671,10 +671,14 @@ final;";
         );
         assert_eq!(
             doc.format().map(|f| &f.leading[..]),
-            Some("\n// This is the first node\n")
+            Some("")
         );
 
         let foo = doc.get("foo").expect("expected a foo node");
+        assert_eq!(
+            foo.format().map(|f| &f.leading[..]),
+            Some("\n// This is the first node\n")
+        );
         assert_eq!(foo.format().map(|f| &f.terminator[..]), Some("\n"));
         assert_eq!(&foo[2], &"three".into());
         assert_eq!(&foo["bar"], &"baz".into());


### PR DESCRIPTION
Fixes #136 