### PR TITLE
fix(lsp): fix char index out of bounds panic in diagnostic positions

### DIFF
--- a/tools/kdl-lsp/src/main.rs
+++ b/tools/kdl-lsp/src/main.rs
@@ -111,8 +111,8 @@ impl LanguageServer for Backend {
                     .map(|diag| {
                         Diagnostic::new(
                             Range::new(
-                                char_to_position(diag.span.offset(), &doc),
-                                char_to_position(diag.span.offset() + diag.span.len(), &doc),
+                                byte_to_position(diag.span.offset(), &doc),
+                                byte_to_position(diag.span.offset() + diag.span.len(), &doc),
                             ),
                             diag.severity().map(to_lsp_sev),
                             diag.code().map(|c| NumberOrString::String(c.to_string())),
@@ -159,7 +159,8 @@ impl LanguageServer for Backend {
     // }
 }
 
-fn char_to_position(char_idx: usize, rope: &Rope) -> Position {
+fn byte_to_position(byte_idx: usize, rope: &Rope) -> Position {
+    let char_idx = rope.byte_to_char(byte_idx);
     let line_idx = rope.char_to_line(char_idx);
     let line_char_idx = rope.line_to_char(line_idx);
     let column_idx = char_idx - line_char_idx;


### PR DESCRIPTION
## Problem
The KDL LSP server panics with "Char index out of bounds" when handling diagnostics. The error occurs because `ropey::Rope` uses character indices internally, but the code was passing byte offsets directly to char-indexing functions.

## Solution
Added a `byte_to_char()` conversion step in the `byte_to_position()` function to properly convert byte indices from parser spans to character indices before calculating line/column positions.

## Changes
- Renamed `char_to_position()` to `byte_to_position()` to accurately reflect its purpose
- Added `rope.byte_to_char(byte_idx)` conversion before calculating position
- Updated all call sites to use the renamed function

This ensures correct position mapping for files with multi-byte characters (UTF-8).