### PR TITLE
fix: fix char index out of bounds panic

### DIFF
--- a/src/v2_parser.rs
+++ b/src/v2_parser.rs
@@ -382,12 +382,12 @@ fn base_node(input: &mut Input<'_>) -> PResult<KdlNode> {
     // _both_ the error message for a string/ident parser error _and_ the error
     // message for a node name being expected.
     if !name_is_valid {
-        resume_after_cut(|input: &mut Input<'_>| -> PResult<()> {
+        resume_after_cut((|input: &mut Input<'_>| -> PResult<()> {
                 Err(ErrMode::Cut(KdlParseError {
                    span: Some(span_from_checkpoint(input, &_before_ident)),
                    ..Default::default()
                 }))
-            }.context(cx().msg("Found invalid node name")
+            }).context(cx().msg("Found invalid node name")
                           .lbl("node name")
                           .hlp("This can be any string type, including a quoted, raw, or multiline string, as well as a plain identifier string.")),
         empty).parse_next(input)?;

--- a/tools/kdl-lsp/src/main.rs
+++ b/tools/kdl-lsp/src/main.rs
@@ -111,8 +111,8 @@ impl LanguageServer for Backend {
                     .map(|diag| {
                         Diagnostic::new(
                             Range::new(
-                                char_to_position(diag.span.offset(), &doc),
-                                char_to_position(diag.span.offset() + diag.span.len(), &doc),
+                                byte_to_position(diag.span.offset(), &doc),
+                                byte_to_position(diag.span.offset() + diag.span.len(), &doc),
                             ),
                             diag.severity().map(to_lsp_sev),
                             diag.code().map(|c| NumberOrString::String(c.to_string())),
@@ -159,7 +159,8 @@ impl LanguageServer for Backend {
     // }
 }
 
-fn char_to_position(char_idx: usize, rope: &Rope) -> Position {
+fn byte_to_position(byte_idx: usize, rope: &Rope) -> Position {
+    let char_idx = rope.byte_to_char(byte_idx);
     let line_idx = rope.char_to_line(char_idx);
     let line_char_idx = rope.line_to_char(line_idx);
     let column_idx = char_idx - line_char_idx;


### PR DESCRIPTION
## Problem
The KDL LSP server panics with "Char index out of bounds". The error occurs because `ropey::Rope` uses character indices internally, but the code was passing byte offsets directly to char-indexing functions.

> thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ropey-1.6.1/src/rope.rs:690:41:
called `Result::unwrap()` on an `Err` value: Char index out of bounds: char index 8272, Rope/RopeSlice char length 8269

## Solution
Added a `byte_to_char()` conversion step in the `byte_to_position()` function to properly convert byte indices from parser spans to character indices before calculating line/column positions.

## Changes
- Renamed `char_to_position()` to `byte_to_position()` to accurately reflect its purpose
- Added `rope.byte_to_char(byte_idx)` conversion before calculating position
- Updated all call sites to use the renamed function