### PR TITLE
fix(lsp): clamp char index to rope length in char_to_position

### DIFF
--- a/tools/kdl-lsp/src/main.rs
+++ b/tools/kdl-lsp/src/main.rs
@@ -160,6 +160,7 @@ impl LanguageServer for Backend {
 }
 
 fn char_to_position(char_idx: usize, rope: &Rope) -> Position {
+    let char_idx = char_idx.min(rope.len_chars());
     let line_idx = rope.char_to_line(char_idx);
     let line_char_idx = rope.line_to_char(line_idx);
     let column_idx = char_idx - line_char_idx;


### PR DESCRIPTION
Prevents a panic when a diagnostic span's end offset lands past
the end of the rope (e.g. on files with no trailing newline).

Fixes kdl-org/vscode-kdl#29