### PR TITLE
fix(v1): stop escaping `/` in ensure_v1

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1126,7 +1126,7 @@ plugins {
         welcome_screen true
     }
     filepicker location="zellij:strider" {
-        cwd "\/"
+        cwd "/"
     }
 }
 mouse_mode false

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2,7 +2,7 @@
 use miette::SourceSpan;
 use std::{fmt::Display, str::FromStr};
 
-use crate::{v2_parser, KdlError, KdlIdentifier, KdlValue};
+use crate::{KdlError, KdlIdentifier, KdlValue, v2_parser};
 
 /// KDL Entries are the "arguments" to KDL nodes: either a (positional)
 /// [`Argument`](https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument) or
@@ -333,10 +333,6 @@ impl KdlEntry {
                             // It's already a v1 string
                             s
                         }
-                    } else if !s.starts_with("r#") {
-                        // `/` is an escaped char in v2
-                        let s = s.replace("\\/", "/"); // Maneuvering. Will fix in a sec.
-                        s.replace('/', "\\/")
                     } else {
                         // We're all good! Let's move on.
                         s.to_string()

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -24,3 +24,34 @@ fn build_and_format() {
 "#
     );
 }
+
+#[test]
+#[cfg(feature = "v1")]
+fn ensure_v1_does_not_over_escape_forward_slash() {
+    // Per the v1 spec, `\/` is a permitted escape but unescaped `/` is also
+    // legal. ensure_v1 should not introduce unnecessary `\/` escapes.
+    let input = "node \"a/b/c\"\n";
+    let mut doc = KdlDocument::parse_v1(input).unwrap();
+    doc.ensure_v1();
+    assert_eq!(doc.to_string(), input);
+}
+
+#[test]
+#[cfg(feature = "v1")]
+fn ensure_v2_strips_escaped_forward_slash() {
+    // `\/` is forbidden in v2, so ensure_v2 must convert it to a `/`.
+    let input = "node \"a\\/b\"\n";
+    let mut doc = KdlDocument::parse_v1(input).unwrap();
+    doc.ensure_v2();
+    assert_eq!(doc.to_string(), "node \"a/b\"\n");
+}
+
+#[test]
+#[cfg(feature = "v1")]
+fn ensure_v1_preserves_raw_string_with_backslash_slash() {
+    // In a raw string, `\/` is two literal characters, and should be kept as is.
+    let input = "node r#\"a\\/b\"#\n";
+    let mut doc = KdlDocument::parse_v1(input).unwrap();
+    doc.ensure_v1();
+    assert_eq!(doc.to_string(), input);
+}


### PR DESCRIPTION
`KdlEntry::ensure_v1` was replacing every `/` in non-raw v1 string literals with `\/`. While that's allowed in v1 (not in v2), it is not necessary.

`ensure_v2` strips `\/`, as expected.