### PR TITLE
chore(deps): update to `winnow` v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,9 +1313,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = ["tools/*"]
 miette.workspace = true
 num-traits = "0.2.19"
 serde = { version = "1.0.210", optional = true }
-winnow = { version = "0.7.13", features = ["alloc", "unstable-recover"] }
+winnow = { version = "1.0.4", features = ["alloc", "unstable-recover"] }
 kdlv1 = { package = "kdl", version = "4.7.0", optional = true }
 
 [workspace.dependencies]


### PR DESCRIPTION
Update to stable `winnow`.

Doesnt seem to need any significant modification code-wise.