### PR TITLE
Fix multi-byte character LSP offset 

### DIFF
--- a/tools/kdl-lsp/src/main.rs
+++ b/tools/kdl-lsp/src/main.rs
@@ -111,8 +111,8 @@ impl LanguageServer for Backend {
                     .map(|diag| {
                         Diagnostic::new(
                             Range::new(
-                                char_to_position(diag.span.offset(), &doc),
-                                char_to_position(diag.span.offset() + diag.span.len(), &doc),
+                                byte_to_position(diag.span.offset(), &doc),
+                                byte_to_position(diag.span.offset() + diag.span.len(), &doc),
                             ),
                             diag.severity().map(to_lsp_sev),
                             diag.code().map(|c| NumberOrString::String(c.to_string())),
@@ -159,12 +159,14 @@ impl LanguageServer for Backend {
     // }
 }
 
-fn char_to_position(char_idx: usize, rope: &Rope) -> Position {
-    let char_idx = char_idx.min(rope.len_chars());
-    let line_idx = rope.char_to_line(char_idx);
-    let line_char_idx = rope.line_to_char(line_idx);
-    let column_idx = char_idx - line_char_idx;
-    Position::new(line_idx as u32, column_idx as u32)
+/// Converts a byte offset to an LSP [`Position`].
+fn byte_to_position(byte_idx: usize, rope: &Rope) -> Position {
+    // Clamp the byte position to the end of the buffer. Just in case.
+    let byte_idx = byte_idx.min(rope.len_bytes());
+    // Get the correct line for that byte offset
+    let line_idx = rope.byte_to_line(byte_idx);
+    let col_idx = rope.byte_to_char(byte_idx) - rope.line_to_char(line_idx);
+    Position::new(line_idx as u32, col_idx as u32)
 }
 
 fn to_lsp_sev(sev: miette::Severity) -> DiagnosticSeverity {

--- a/tools/kdl-lsp/src/main.rs
+++ b/tools/kdl-lsp/src/main.rs
@@ -160,12 +160,20 @@ impl LanguageServer for Backend {
 }
 
 /// Converts a byte offset to an LSP [`Position`].
+///
+/// This panics when we feed it a byte index that falls somewhere inside a multi-byte UTF-8 char.
 fn byte_to_position(byte_idx: usize, rope: &Rope) -> Position {
     // Clamp the byte position to the end of the buffer. Just in case.
     let byte_idx = byte_idx.min(rope.len_bytes());
     // Get the correct line for that byte offset
     let line_idx = rope.byte_to_line(byte_idx);
-    let col_idx = rope.byte_to_char(byte_idx) - rope.line_to_char(line_idx);
+    // Calculate the correct UTF-16 code unit.
+    // The LSP doesn't use characters for columns, but instead for some reason they chose to use
+    // UTF-16 code units.
+    // If not not explicitly handled as such, passing a UTF-8 char column position would result
+    // in a shift of one char backwards per prior 4-byte UTF-16 character in the current line.
+    let col_idx = rope.char_to_utf16_cu(rope.byte_to_char(byte_idx))
+        - rope.char_to_utf16_cu(rope.line_to_char(line_idx));
     Position::new(line_idx as u32, col_idx as u32)
 }
 


### PR DESCRIPTION
Heyo :)

While tinkering on my own LSP implementation, I snatched a few parts from kdl-lsp and found two bugs.
I played around to see how the LSP reacts to multi-byte UTF-8 chars and saw that there's an offset.

Having had my fair share of UTF-8 shenanigans in comfy-table, I gave it a try.

The first issue was that the previous logic took miette's diagnostic span offsets (which are bytes) and used that to calculate the diagnostic position offsets via ropey's char methods.

This works as long as the document contained pure ASCII, but as soon as multi-byte chars were handled, there was an offset in the form of amount of non-ascii bytes.

The following, for example, would position the error pointer at the
`v` of `version`
```
name "Line with emoji😀"

asdf {
    rofl omfg=
}
version "1.0"
```
<img width="259" height="127" alt="grafik" src="https://github.com/user-attachments/assets/85cc87e4-44ee-4041-954e-2a1e173318b2" />

After fixing the byte offsets from utf-8 bytes, there's still this issue:

<img width="483" height="91" alt="grafik" src="https://github.com/user-attachments/assets/df260dd6-5cbb-4688-930b-bfe56c81193d" />

It turns out that the language server protocol uses UTF-16, coming from microsoft and all.
And the Position they expect via the wire protocol isn't the character position, but rather the UTF-16 code unit position.
So just sending the correct character position, isn't enough, you need to take into account how many characters with multiple 16-byte chunks are in the current line.

Luckily ropey already has some convenience methods for that, which made the actual fix rather trivial.

Please double check though.

On a fun sidenote: I learned that the 3.17 LSP spec introduced a [encoding negotiation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments). However, since most clients probably only use UTF-16, it will probably take some time until this can be flipped to UTF-8. 

Cheers