### PR TITLE
fix(parser): Correct error span for faulty property values

### DIFF
--- a/src/v2_parser.rs
+++ b/src/v2_parser.rs
@@ -555,11 +555,16 @@ fn node_entry(input: &mut Input<'_>) -> PResult<Option<KdlEntry>> {
         None
     };
     let entry = if let Some(after_key) = after_key {
-        let (after_eq, value) = (
-            node_space0.take(),
-            cut_err(value.context(cx().lbl("property value"))),
-        )
-            .parse_next(input)?;
+        let after_eq = node_space0.take().parse_next(input)?;
+        let _span = input.checkpoint();
+        let value = cut_err(value.context(cx().lbl("property value")))
+            .parse_next(input)
+            .map_err(|e| {
+                e.map(|mut e: KdlParseError| {
+                    e.span = e.span.or_else(|| Some(span_from_checkpoint(input, &_span)));
+                    e
+                })
+            })?;
         value.map(|mut value| {
             value.name = maybe_ident;
             if let Some(fmt) = value.format_mut() {


### PR DESCRIPTION
While debugging #171, i saw that the diagnostics span for incomplete property values was from the beginning of the document until the point of the error:

```kdl
name "Line with emoji😀"

asdf {
    rofl omfg=
}

version "1.0"
```

<img width="276" height="146" alt="grafik" src="https://github.com/user-attachments/assets/79d47e0b-d063-42c5-8c55-300a976f4573" />

Since we wrote all of our parsers in ALPM in winnow, i found my way around.

I'm not 100% sure if that's the correct way to fix, but I took the other span definitions as a guideline and it now produces the correct error span.

I also wasn't sure how to best test this as well. In case you want some tests for this, just give me a hint on where and which way to test this best :) 

Cheers